### PR TITLE
design: Update delete buttons for modals

### DIFF
--- a/src/components/Pages/Admin/AddressItemDisplay.tsx
+++ b/src/components/Pages/Admin/AddressItemDisplay.tsx
@@ -206,22 +206,15 @@ export const AddressItemDisplay = ({
           </ModalBody>
           <ModalFooter justifyContent="flex-end">
             <Flex>
-              <Button
-                onClick={onDeleteModalClose}
-                color={"white"}
-                background={colorMode === "light" ? "red.500" : "red.600"}
-                _hover={{
-                  background: colorMode === "light" ? "red.400" : "red.500",
-                }}
-              >
+              <Button onClick={onDeleteModalClose} colorScheme={"gray"}>
                 No
               </Button>
               <Button
                 onClick={deleteBtnClicked}
                 color={"white"}
-                background={colorMode === "light" ? "green.500" : "green.600"}
+                background={colorMode === "light" ? "red.500" : "red.600"}
                 _hover={{
-                  background: colorMode === "light" ? "green.400" : "green.500",
+                  background: colorMode === "light" ? "red.400" : "red.500",
                 }}
                 ml={3}
               >

--- a/src/components/Pages/Admin/BranchItemDisplay.tsx
+++ b/src/components/Pages/Admin/BranchItemDisplay.tsx
@@ -241,22 +241,15 @@ export const BranchItemDisplay = ({ pk, agency, name, manager }: IBranch) => {
           </ModalBody>
           <ModalFooter justifyContent="flex-end">
             <Flex>
-              <Button
-                onClick={onDeleteModalClose}
-                color={"white"}
-                background={colorMode === "light" ? "red.500" : "red.600"}
-                _hover={{
-                  background: colorMode === "light" ? "red.400" : "red.500",
-                }}
-              >
+              <Button onClick={onDeleteModalClose} colorScheme={"gray"}>
                 No
               </Button>
               <Button
                 onClick={deleteBtnClicked}
                 color={"white"}
-                background={colorMode === "light" ? "green.500" : "green.600"}
+                background={colorMode === "light" ? "red.500" : "red.600"}
                 _hover={{
-                  background: colorMode === "light" ? "green.400" : "green.500",
+                  background: colorMode === "light" ? "red.400" : "red.500",
                 }}
                 ml={3}
               >

--- a/src/components/Pages/Admin/BusinessAreaItemDisplay.tsx
+++ b/src/components/Pages/Admin/BusinessAreaItemDisplay.tsx
@@ -423,22 +423,15 @@ export const BusinessAreaItemDisplay = ({
           </ModalBody>
           <ModalFooter justifyContent="flex-end">
             <Flex>
-              <Button
-                onClick={onDeleteModalClose}
-                color={"white"}
-                background={colorMode === "light" ? "red.500" : "red.600"}
-                _hover={{
-                  background: colorMode === "light" ? "red.400" : "red.500",
-                }}
-              >
+              <Button onClick={onDeleteModalClose} colorScheme={"gray"}>
                 No
               </Button>
               <Button
                 onClick={deleteBtnClicked}
                 color={"white"}
-                background={colorMode === "light" ? "green.500" : "green.600"}
+                background={colorMode === "light" ? "red.500" : "red.600"}
                 _hover={{
-                  background: colorMode === "light" ? "green.400" : "green.500",
+                  background: colorMode === "light" ? "red.400" : "red.500",
                 }}
                 ml={3}
               >

--- a/src/components/Pages/Admin/DivisionItemDisplay.tsx
+++ b/src/components/Pages/Admin/DivisionItemDisplay.tsx
@@ -292,22 +292,15 @@ export const DivisionItemDisplay = ({
           </ModalBody>
           <ModalFooter justifyContent="flex-end">
             <Flex>
-              <Button
-                onClick={onDeleteModalClose}
-                color={"white"}
-                background={colorMode === "light" ? "red.500" : "red.600"}
-                _hover={{
-                  background: colorMode === "light" ? "red.400" : "red.500",
-                }}
-              >
+              <Button onClick={onDeleteModalClose} colorScheme={"gray"}>
                 No
               </Button>
               <Button
                 onClick={deleteBtnClicked}
                 color={"white"}
-                background={colorMode === "light" ? "green.500" : "green.600"}
+                background={colorMode === "light" ? "red.500" : "red.600"}
                 _hover={{
-                  background: colorMode === "light" ? "green.400" : "green.500",
+                  background: colorMode === "light" ? "red.400" : "red.500",
                 }}
                 ml={3}
               >

--- a/src/components/Pages/Admin/LocationItemDisplay.tsx
+++ b/src/components/Pages/Admin/LocationItemDisplay.tsx
@@ -182,22 +182,15 @@ export const LocationItemDisplay = ({
           </ModalBody>
           <ModalFooter justifyContent="flex-end">
             <Flex>
-              <Button
-                onClick={onDeleteModalClose}
-                color={"white"}
-                background={colorMode === "light" ? "red.500" : "red.600"}
-                _hover={{
-                  background: colorMode === "light" ? "red.400" : "red.500",
-                }}
-              >
+              <Button onClick={onDeleteModalClose} colorScheme={"gray"}>
                 No
               </Button>
               <Button
                 onClick={deleteBtnClicked}
                 color={"white"}
-                background={colorMode === "light" ? "green.500" : "green.600"}
+                background={colorMode === "light" ? "red.500" : "red.600"}
                 _hover={{
-                  background: colorMode === "light" ? "green.400" : "green.500",
+                  background: colorMode === "light" ? "red.400" : "red.500",
                 }}
                 ml={3}
               >

--- a/src/components/Pages/Admin/ReportItemDisplay.tsx
+++ b/src/components/Pages/Admin/ReportItemDisplay.tsx
@@ -549,22 +549,15 @@ export const ReportItemDisplay = ({
           </ModalBody>
           <ModalFooter justifyContent="flex-end">
             <Flex>
-              <Button
-                onClick={onDeleteModalClose}
-                color={"white"}
-                background={colorMode === "light" ? "red.500" : "red.600"}
-                _hover={{
-                  background: colorMode === "light" ? "red.400" : "red.500",
-                }}
-              >
+              <Button onClick={onDeleteModalClose} colorScheme={"gray"}>
                 No
               </Button>
               <Button
                 onClick={deleteBtnClicked}
                 color={"white"}
-                background={colorMode === "light" ? "green.500" : "green.600"}
+                background={colorMode === "light" ? "red.500" : "red.600"}
                 _hover={{
-                  background: colorMode === "light" ? "green.400" : "green.500",
+                  background: colorMode === "light" ? "red.400" : "red.500",
                 }}
                 ml={3}
               >

--- a/src/components/Pages/Admin/ResearchFunctionItemDisplay.tsx
+++ b/src/components/Pages/Admin/ResearchFunctionItemDisplay.tsx
@@ -259,22 +259,15 @@ export const ResearchFunctionItemDisplay = ({
           </ModalBody>
           <ModalFooter justifyContent="flex-end">
             <Flex>
-              <Button
-                onClick={onDeleteModalClose}
-                color={"white"}
-                background={colorMode === "light" ? "red.500" : "red.600"}
-                _hover={{
-                  background: colorMode === "light" ? "red.400" : "red.500",
-                }}
-              >
+              <Button onClick={onDeleteModalClose} colorScheme={"gray"}>
                 No
               </Button>
               <Button
                 onClick={deleteButtonClick}
                 color={"white"}
-                background={colorMode === "light" ? "green.500" : "green.600"}
+                background={colorMode === "light" ? "red.500" : "red.600"}
                 _hover={{
-                  background: colorMode === "light" ? "green.400" : "green.500",
+                  background: colorMode === "light" ? "red.400" : "red.500",
                 }}
                 ml={3}
               >

--- a/src/components/Pages/Admin/ServiceItemDisplay.tsx
+++ b/src/components/Pages/Admin/ServiceItemDisplay.tsx
@@ -241,22 +241,15 @@ export const ServiceItemDisplay = ({
           </ModalBody>
           <ModalFooter justifyContent="flex-end">
             <Flex>
-              <Button
-                onClick={onDeleteModalClose}
-                color={"white"}
-                background={colorMode === "light" ? "red.500" : "red.600"}
-                _hover={{
-                  background: colorMode === "light" ? "red.400" : "red.500",
-                }}
-              >
+              <Button onClick={onDeleteModalClose} colorScheme={"gray"}>
                 No
               </Button>
               <Button
                 onClick={deleteBtnClicked}
                 color={"white"}
-                background={colorMode === "light" ? "green.500" : "green.600"}
+                background={colorMode === "light" ? "red.500" : "red.600"}
                 _hover={{
-                  background: colorMode === "light" ? "green.400" : "green.500",
+                  background: colorMode === "light" ? "red.400" : "red.500",
                 }}
                 ml={3}
               >


### PR DESCRIPTION
Based on Ben's advise. Instead of green for the confirmation of delete and red for cancel, changed to gray for cancel and red to confirm - ensuring user knows it is a destructive action.