### PR TITLE
fix: All PRs shown regardless of project status

### DIFF
--- a/src/components/Pages/CurrentReport/LatestReportsNotYetApproved.tsx
+++ b/src/components/Pages/CurrentReport/LatestReportsNotYetApproved.tsx
@@ -6,222 +6,258 @@ import { ARStudentReportHandler } from "@/components/RichTextEditor/Editors/ARSt
 import { useLatestYearsUnapprovedReports } from "@/lib/hooks/tanstack/useLatestReportsUnapproved";
 import { useUser } from "@/lib/hooks/tanstack/useUser";
 import {
-  Accordion,
-  AccordionButton,
-  AccordionItem,
-  AccordionPanel,
-  Box,
-  Center,
-  Flex,
-  Spinner,
-  Text,
-  useColorMode,
+	Accordion,
+	AccordionButton,
+	AccordionItem,
+	AccordionPanel,
+	Box,
+	Center,
+	Flex,
+	Spinner,
+	Text,
+	useColorMode,
 } from "@chakra-ui/react";
 import { MdScience } from "react-icons/md";
 import { RiBook3Fill } from "react-icons/ri";
 
 export const LatestReportsNotYetApproved = () => {
-  const { unapprovedData, unapprovedLoading } =
-    useLatestYearsUnapprovedReports();
+	const { unapprovedData, unapprovedLoading } =
+		useLatestYearsUnapprovedReports();
 
-  const { userData, userLoading } = useUser();
+	const { userData, userLoading } = useUser();
 
-  const A4Width = 210; // in millimeters
-  const A4Height = A4Width * 1.414; // 1.414 is the aspect ratio of A4 paper (297 / 210)
+	const A4Width = 210; // in millimeters
+	const A4Height = A4Width * 1.414; // 1.414 is the aspect ratio of A4 paper (297 / 210)
 
-  const { colorMode } = useColorMode();
+	const { colorMode } = useColorMode();
 
-  return (
-    <Box w={"100%"}>
-      {unapprovedLoading || unapprovedData === undefined ? (
-        <Center>
-          <Spinner />
-        </Center>
-      ) : (
-        <Box
-          display={"flex"}
-          flexDir={"column"}
-          margin={"auto"}
-          minH={`${A4Height}mm`}
-          maxW={`${A4Width}mm`}
-          py={4}
-          // bg={"orange"}
-          position="relative"
+	return (
+		<Box w={"100%"}>
+			{unapprovedLoading || unapprovedData === undefined ? (
+				<Center>
+					<Spinner />
+				</Center>
+			) : (
+				<Box
+					display={"flex"}
+					flexDir={"column"}
+					margin={"auto"}
+					minH={`${A4Height}mm`}
+					maxW={`${A4Width}mm`}
+					py={4}
+					// bg={"orange"}
+					position="relative"
 
-        // zIndex={1}
-        >
-          <Box
-            position="absolute"
-            minH={`${A4Height}mm`}
-            top="0"
-            left="0"
-            right="0"
-            bottom="0"
-            // backgroundImage={`url(${whitePaperBackground})`}
-            background={"white"}
-            backgroundSize="cover"
-            backgroundPosition="center"
-            backgroundRepeat="no-repeat"
-            // transform="rotate(90deg)" // Rotate the background image by 90 degrees
-            opacity={0.25} // Set the opacity of the background image
-            zIndex={0}
-          />
-          {unapprovedData["student_reports"].length +
-            unapprovedData["progress_reports"].length <
-            1 ? (
-            <Center>
-              <Text pos={"absolute"} top={10}>
-                There are no unapproved reports for this year
-              </Text>
-            </Center>
-          ) : (
-            <Accordion
-              defaultIndex={[0]}
-              allowMultiple
-              zIndex={2}
-              w={"100%"}
-            // bg={"red"}
-            >
-              <AccordionItem
-                mt={-4}
-                borderColor={
-                  colorMode === "light" ? "blackAlpha.500" : "whiteAlpha.600"
-                }
-                borderBottom={"none"}
-                borderTop={"none"}
-                zIndex={999}
-                opacity={1.5}
-                w={"100%"}
-              >
-                <AccordionButton
-                  // bg={colorMode === "light" ? "gray.200" : "gray.700"}
-                  bg={colorMode === "light" ? "blue.500" : "blue.600"}
-                  w={"100%"}
-                  color={"white"}
-                  _hover={
-                    colorMode === "light"
-                      ? { bg: "blue.400" }
-                      : { bg: "blue.500" }
-                  }
-                  userSelect={"none"}
-                  opacity={0.9}
-                  borderBottomRadius={"50%"}
-                  alignItems={"center"}
-                  justifyContent={"center"}
-                >
-                  <Center mb={4} mt={4} ml={6}>
-                    <Box
-                      display="flex"
-                      alignItems="center"
-                      justifyContent="center"
-                      width={8}
-                      height={8}
-                      mr={4}
-                    >
-                      <RiBook3Fill size={"lg"} />
-                    </Box>
-                    <Text
-                      fontWeight={"bold"}
-                      fontSize={"xl"}
-                    // color={"black"}
-                    >
-                      Student Reports (
-                      {unapprovedData["student_reports"].length})
-                    </Text>
-                  </Center>
-                </AccordionButton>
-                <AccordionPanel py={4} mt={4}>
-                  {unapprovedData &&
-                    unapprovedData["student_reports"]?.map((sr, index) => {
-                      return (
-                        <ARStudentReportHandler
-                          key={`student${index}`}
-                          canEdit={
-                            userData?.is_superuser ||
-                            userData?.business_area?.name === "Directorate"
-                          }
-                          report={sr}
-                          shouldAlternatePicture={index % 2 !== 0}
-                        />
-                      );
-                    })}
-                </AccordionPanel>
-              </AccordionItem>
+					// zIndex={1}
+				>
+					<Box
+						position="absolute"
+						minH={`${A4Height}mm`}
+						top="0"
+						left="0"
+						right="0"
+						bottom="0"
+						// backgroundImage={`url(${whitePaperBackground})`}
+						background={"white"}
+						backgroundSize="cover"
+						backgroundPosition="center"
+						backgroundRepeat="no-repeat"
+						// transform="rotate(90deg)" // Rotate the background image by 90 degrees
+						opacity={0.25} // Set the opacity of the background image
+						zIndex={0}
+					/>
+					{unapprovedData["student_reports"].length +
+						unapprovedData["progress_reports"].length <
+					1 ? (
+						<Center>
+							<Text pos={"absolute"} top={10}>
+								There are no unapproved reports for this year
+							</Text>
+						</Center>
+					) : (
+						<Accordion
+							defaultIndex={[0]}
+							allowMultiple
+							zIndex={2}
+							w={"100%"}
+							// bg={"red"}
+						>
+							<AccordionItem
+								mt={-4}
+								borderColor={
+									colorMode === "light"
+										? "blackAlpha.500"
+										: "whiteAlpha.600"
+								}
+								borderBottom={"none"}
+								borderTop={"none"}
+								zIndex={999}
+								opacity={1.5}
+								w={"100%"}
+							>
+								<AccordionButton
+									// bg={colorMode === "light" ? "gray.200" : "gray.700"}
+									bg={
+										colorMode === "light"
+											? "blue.500"
+											: "blue.600"
+									}
+									w={"100%"}
+									color={"white"}
+									_hover={
+										colorMode === "light"
+											? { bg: "blue.400" }
+											: { bg: "blue.500" }
+									}
+									userSelect={"none"}
+									opacity={0.9}
+									borderBottomRadius={"50%"}
+									alignItems={"center"}
+									justifyContent={"center"}
+								>
+									<Center mb={4} mt={4} ml={6}>
+										<Box
+											display="flex"
+											alignItems="center"
+											justifyContent="center"
+											width={8}
+											height={8}
+											mr={4}
+										>
+											<RiBook3Fill size={"lg"} />
+										</Box>
+										<Text
+											fontWeight={"bold"}
+											fontSize={"xl"}
+											// color={"black"}
+										>
+											Student Reports (
+											{
+												unapprovedData[
+													"student_reports"
+												].length
+											}
+											)
+										</Text>
+									</Center>
+								</AccordionButton>
+								<AccordionPanel py={4} mt={4}>
+									{unapprovedData &&
+										unapprovedData["student_reports"]?.map(
+											(sr, index) => {
+												return (
+													<ARStudentReportHandler
+														key={`student${index}`}
+														canEdit={
+															userData?.is_superuser ||
+															userData
+																?.business_area
+																?.name ===
+																"Directorate"
+														}
+														report={sr}
+														shouldAlternatePicture={
+															index % 2 !== 0
+														}
+													/>
+												);
+											}
+										)}
+								</AccordionPanel>
+							</AccordionItem>
 
-              <AccordionItem
-                mt={4}
-                borderColor={
-                  colorMode === "light" ? "blackAlpha.500" : "whiteAlpha.600"
-                }
-                borderBottom={"none"}
-                borderTop={"none"}
-                zIndex={999}
-                opacity={1.5}
-                w={"100%"}
-              >
-                <AccordionButton
-                  // bg={colorMode === "light" ? "gray.200" : "gray.700"}
-                  bg={colorMode === "light" ? "green.500" : "green.600"}
-                  w={"100%"}
-                  color={"white"}
-                  _hover={
-                    colorMode === "light"
-                      ? { bg: "green.400" }
-                      : { bg: "green.500" }
-                  }
-                  userSelect={"none"}
-                  opacity={0.9}
-                  borderBottomRadius={"50%"}
-                  alignItems={"center"}
-                  justifyContent={"center"}
-                >
-                  <Flex mb={4} mt={4} ml={6}>
-                    <Box
-                      display="flex"
-                      alignItems="center"
-                      justifyContent="center"
-                      width={8}
-                      height={8}
-                      mr={4}
-                    >
-                      <MdScience size={"lg"} />
-                    </Box>
-                    <Text
-                      fontWeight={"bold"}
-                      fontSize={"xl"}
-                    // color={"black"}
-                    >
-                      Progress Reports (
-                      {unapprovedData["progress_reports"].length})
-                    </Text>
-                  </Flex>
-                </AccordionButton>
-                <AccordionPanel py={4} mt={4}>
-                  {unapprovedData &&
-                    unapprovedData["progress_reports"]?.map((pr, index) => {
-                      return (
-                        <ARProgressReportHandler
-                          key={`ordinary${index}`}
-                          canEdit={
-                            userData?.is_superuser ||
-                            userData?.business_area?.name === "Directorate"
-                          }
-                          report={pr}
-                          shouldAlternatePicture={index % 2 !== 0}
-                        />
-                      );
-                    })}
-                </AccordionPanel>
-              </AccordionItem>
-            </Accordion>
-          )}
-        </Box>
-      )}
-    </Box>
-  );
+							<AccordionItem
+								mt={4}
+								borderColor={
+									colorMode === "light"
+										? "blackAlpha.500"
+										: "whiteAlpha.600"
+								}
+								borderBottom={"none"}
+								borderTop={"none"}
+								zIndex={999}
+								opacity={1.5}
+								w={"100%"}
+							>
+								<AccordionButton
+									// bg={colorMode === "light" ? "gray.200" : "gray.700"}
+									bg={
+										colorMode === "light"
+											? "green.500"
+											: "green.600"
+									}
+									w={"100%"}
+									color={"white"}
+									_hover={
+										colorMode === "light"
+											? { bg: "green.400" }
+											: { bg: "green.500" }
+									}
+									userSelect={"none"}
+									opacity={0.9}
+									borderBottomRadius={"50%"}
+									alignItems={"center"}
+									justifyContent={"center"}
+								>
+									<Flex mb={4} mt={4} ml={6}>
+										<Box
+											display="flex"
+											alignItems="center"
+											justifyContent="center"
+											width={8}
+											height={8}
+											mr={4}
+										>
+											<MdScience size={"lg"} />
+										</Box>
+										<Text
+											fontWeight={"bold"}
+											fontSize={"xl"}
+											// color={"black"}
+										>
+											Progress Reports (
+											{
+												unapprovedData[
+													"progress_reports"
+												].length
+											}
+											)
+										</Text>
+									</Flex>
+								</AccordionButton>
+								<AccordionPanel py={4} mt={4}>
+									{unapprovedData &&
+										unapprovedData["progress_reports"]?.map(
+											(pr, index) => {
+												return (
+													<ARProgressReportHandler
+														key={`ordinary${index}`}
+														canEdit={
+															userData?.is_superuser ||
+															userData
+																?.business_area
+																?.name ===
+																"Directorate"
+														}
+														report={pr}
+														shouldAlternatePicture={
+															index % 2 !== 0
+														}
+													/>
+												);
+											}
+										)}
+								</AccordionPanel>
+							</AccordionItem>
+						</Accordion>
+					)}
+				</Box>
+			)}
+		</Box>
+	);
 };
 {
-  /* {unapprovedData &&
+	/* {unapprovedData &&
             unapprovedData["progress_reports"]?.map((pr, index) => {
               return (
                 <Box key={`progress${index}`}>

--- a/src/components/Pages/CurrentReport/ParticipatingProjectReports.tsx
+++ b/src/components/Pages/CurrentReport/ParticipatingProjectReports.tsx
@@ -5,15 +5,15 @@ import { useLatestYearsActiveProgressReports } from "@/lib/hooks/tanstack/useLat
 import { useLatestYearsActiveStudentProjects } from "@/lib/hooks/tanstack/useLatestYearsActiveStudentProjects";
 import { useUser } from "@/lib/hooks/tanstack/useUser";
 import {
-  Accordion,
-  AccordionButton,
-  AccordionItem,
-  AccordionPanel,
-  Box,
-  Center,
-  Spinner,
-  Text,
-  useColorMode,
+	Accordion,
+	AccordionButton,
+	AccordionItem,
+	AccordionPanel,
+	Box,
+	Center,
+	Spinner,
+	Text,
+	useColorMode,
 } from "@chakra-ui/react";
 // import {
 // JSXElementConstructor, ReactElement,
@@ -25,219 +25,252 @@ import { RiBook3Fill } from "react-icons/ri";
 // import { render } from "@react-email/render";
 
 export const ParticipatingProjectReports = () => {
-  const { latestProgressReportsData, latestProgressReportsLoading } =
-    useLatestYearsActiveProgressReports();
+	const { latestProgressReportsData, latestProgressReportsLoading } =
+		useLatestYearsActiveProgressReports();
 
-  const { latestStudentReportsData, latestStudentReportsLoading } =
-    useLatestYearsActiveStudentProjects();
+	const { latestStudentReportsData, latestStudentReportsLoading } =
+		useLatestYearsActiveStudentProjects();
 
-  // const getHTML = (children: ReactElement<any, string | JSXElementConstructor<any>>) => {
-  //   const html = render(children, {
-  //     pretty: true,
-  //   });
+	// const getHTML = (children: ReactElement<any, string | JSXElementConstructor<any>>) => {
+	//   const html = render(children, {
+	//     pretty: true,
+	//   });
 
-  //   console.log(html);
+	//   console.log(html);
 
-  // }
+	// }
 
-  // useEffect(() => {
-  //   if (!latestProgressReportsLoading && !latestStudentReportsLoading) {
-  //     console.log({
-  //       "student": latestStudentReportsData,
-  //       "other": latestProgressReportsData
-  //     })
-  //   }
-  // }, [latestProgressReportsData, latestStudentReportsData, latestProgressReportsLoading, latestStudentReportsLoading])
+	// useEffect(() => {
+	//   if (!latestProgressReportsLoading && !latestStudentReportsLoading) {
+	//     console.log({
+	//       "student": latestStudentReportsData,
+	//       "other": latestProgressReportsData
+	//     })
+	//   }
+	// }, [latestProgressReportsData, latestStudentReportsData, latestProgressReportsLoading, latestStudentReportsLoading])
 
-  const { userData, userLoading } = useUser();
-  const A4Width = 210; // in millimeters
-  const A4Height = A4Width * 1.414; // 1.414 is the aspect ratio of A4 paper (297 / 210)
+	const { userData, userLoading } = useUser();
+	const A4Width = 210; // in millimeters
+	const A4Height = A4Width * 1.414; // 1.414 is the aspect ratio of A4 paper (297 / 210)
 
-  const { colorMode } = useColorMode();
+	const { colorMode } = useColorMode();
 
-  return (
-    <Box>
-      {latestProgressReportsLoading || latestStudentReportsLoading ? (
-        <Center>
-          <Spinner />
-        </Center>
-      ) : (
-        <Box
-          display={"flex"}
-          flexDir={"column"}
-          margin={"auto"}
-          maxW={`${A4Width}mm`}
-          minH={`${A4Height}mm`}
-          py={4}
-          // bg={"orange"}
-          position="relative"
-        // zIndex={1}
-        >
-          <Box
-            position="absolute"
-            top="0"
-            left="0"
-            right="0"
-            bottom="0"
-            minH={`${A4Height}mm`}
-            // 
-            background={"white"}
-            backgroundSize="cover"
-            backgroundPosition="center"
-            backgroundRepeat="no-repeat"
-            // transform="rotate(90deg)" // Rotate the background image by 90 degrees
-            opacity={0.25} // Set the opacity of the background image
-            zIndex={0}
-          />
-          {latestStudentReportsData?.length +
-            latestProgressReportsData?.length <
-            1 ? (
-            <Center>
-              <Text pos={"absolute"} top={10}>
-                There are no approved reports for this year
-              </Text>
-            </Center>
-          ) : (
-            <Accordion defaultIndex={[1]} allowMultiple zIndex={2} w={"100%"}>
-              <AccordionItem
-                mt={-4}
-                borderColor={
-                  colorMode === "light" ? "blackAlpha.500" : "whiteAlpha.600"
-                }
-                borderBottom={"none"}
-                borderTop={"none"}
-                zIndex={999}
-                opacity={1.5}
-                w={"100%"}
-              >
-                <AccordionButton
-                  // bg={colorMode === "light" ? "gray.200" : "gray.700"}
-                  bg={colorMode === "light" ? "blue.500" : "blue.600"}
-                  w={"100%"}
-                  color={"white"}
-                  _hover={
-                    colorMode === "light"
-                      ? { bg: "blue.400" }
-                      : { bg: "blue.500" }
-                  }
-                  userSelect={"none"}
-                  opacity={0.9}
-                  borderBottomRadius={"50%"}
-                  alignItems={"center"}
-                  justifyContent={"center"}
-                >
-                  <Center mb={4} mt={4} ml={6}>
-                    <Box
-                      display="flex"
-                      alignItems="center"
-                      justifyContent="center"
-                      width={8}
-                      height={8}
-                      mr={4}
-                    >
-                      <RiBook3Fill size={"lg"} />
-                    </Box>
-                    <Text
-                      fontWeight={"bold"}
-                      fontSize={"xl"}
-                    // color={"black"}
-                    >
-                      Student Reports ({latestStudentReportsData?.length})
-                    </Text>
-                  </Center>
-                </AccordionButton>
-                <AccordionPanel py={4} mt={4}>
-                  {!userLoading &&
-                    latestStudentReportsData?.map((sr, index) => {
-                      return (
-                        <ARStudentReportHandler
-                          key={`student${index}`}
-                          canEdit={
-                            userData?.is_superuser ||
-                            userData?.business_area?.name === "Directorate"
-                          }
-                          report={sr}
-                          shouldAlternatePicture={index % 2 !== 0}
-                        />
-                      );
-                    })}
-                </AccordionPanel>
-              </AccordionItem>
+	return (
+		<Box>
+			{latestProgressReportsLoading || latestStudentReportsLoading ? (
+				<Center>
+					<Spinner />
+				</Center>
+			) : (
+				<Box
+					display={"flex"}
+					flexDir={"column"}
+					margin={"auto"}
+					maxW={`${A4Width}mm`}
+					minH={`${A4Height}mm`}
+					py={4}
+					// bg={"orange"}
+					position="relative"
+					// zIndex={1}
+				>
+					<Box
+						position="absolute"
+						top="0"
+						left="0"
+						right="0"
+						bottom="0"
+						minH={`${A4Height}mm`}
+						//
+						background={"white"}
+						backgroundSize="cover"
+						backgroundPosition="center"
+						backgroundRepeat="no-repeat"
+						// transform="rotate(90deg)" // Rotate the background image by 90 degrees
+						opacity={0.25} // Set the opacity of the background image
+						zIndex={0}
+					/>
+					{latestStudentReportsData?.length +
+						latestProgressReportsData?.length <
+					1 ? (
+						<Center>
+							<Text pos={"absolute"} top={10}>
+								There are no approved reports for this year
+							</Text>
+						</Center>
+					) : (
+						<Accordion
+							defaultIndex={[1]}
+							allowMultiple
+							zIndex={2}
+							w={"100%"}
+						>
+							<AccordionItem
+								mt={-4}
+								borderColor={
+									colorMode === "light"
+										? "blackAlpha.500"
+										: "whiteAlpha.600"
+								}
+								borderBottom={"none"}
+								borderTop={"none"}
+								zIndex={999}
+								opacity={1.5}
+								w={"100%"}
+							>
+								<AccordionButton
+									// bg={colorMode === "light" ? "gray.200" : "gray.700"}
+									bg={
+										colorMode === "light"
+											? "blue.500"
+											: "blue.600"
+									}
+									w={"100%"}
+									color={"white"}
+									_hover={
+										colorMode === "light"
+											? { bg: "blue.400" }
+											: { bg: "blue.500" }
+									}
+									userSelect={"none"}
+									opacity={0.9}
+									borderBottomRadius={"50%"}
+									alignItems={"center"}
+									justifyContent={"center"}
+								>
+									<Center mb={4} mt={4} ml={6}>
+										<Box
+											display="flex"
+											alignItems="center"
+											justifyContent="center"
+											width={8}
+											height={8}
+											mr={4}
+										>
+											<RiBook3Fill size={"lg"} />
+										</Box>
+										<Text
+											fontWeight={"bold"}
+											fontSize={"xl"}
+											// color={"black"}
+										>
+											Student Reports (
+											{latestStudentReportsData?.length})
+										</Text>
+									</Center>
+								</AccordionButton>
+								<AccordionPanel py={4} mt={4}>
+									{!userLoading &&
+										latestStudentReportsData?.map(
+											(sr, index) => {
+												return (
+													<ARStudentReportHandler
+														key={`student${index}`}
+														canEdit={
+															userData?.is_superuser ||
+															userData
+																?.business_area
+																?.name ===
+																"Directorate"
+														}
+														report={sr}
+														shouldAlternatePicture={
+															index % 2 !== 0
+														}
+													/>
+												);
+											}
+										)}
+								</AccordionPanel>
+							</AccordionItem>
 
-              <AccordionItem
-                mt={4}
-                borderColor={
-                  colorMode === "light" ? "blackAlpha.500" : "whiteAlpha.600"
-                }
-                borderBottom={"none"}
-                borderTop={"none"}
-                zIndex={999}
-                opacity={1.5}
-                w={"100%"}
-              >
-                <AccordionButton
-                  // bg={colorMode === "light" ? "gray.200" : "gray.700"}
-                  bg={colorMode === "light" ? "green.500" : "green.600"}
-                  w={"100%"}
-                  color={"white"}
-                  _hover={
-                    colorMode === "light"
-                      ? { bg: "green.400" }
-                      : { bg: "green.500" }
-                  }
-                  userSelect={"none"}
-                  opacity={0.9}
-                  borderBottomRadius={"50%"}
-                  alignItems={"center"}
-                  justifyContent={"center"}
-                >
-                  <Center mb={4} mt={4} ml={6}>
-                    <Box
-                      display="flex"
-                      alignItems="center"
-                      justifyContent="center"
-                      width={8}
-                      height={8}
-                      mr={4}
-                    >
-                      <MdScience size={"lg"} />
-                    </Box>
-                    <Text
-                      fontWeight={"bold"}
-                      fontSize={"xl"}
-                    // color={"black"}
-                    >
-                      Progress Reports ({latestProgressReportsData?.length})
-                    </Text>
-                  </Center>
-                </AccordionButton>
-                <AccordionPanel py={4} mt={4}>
-                  {latestProgressReportsData &&
-                    latestProgressReportsData?.map((pr, index) => {
-                      return (
-                        <ARProgressReportHandler
-                          key={`ordinary${index}`}
-                          canEdit={
-                            userData?.is_superuser ||
-                            userData?.business_area?.name === "Directorate"
-                          }
-                          report={pr}
-                          shouldAlternatePicture={index % 2 !== 0}
-                        />
-                      );
-                    })}
-                </AccordionPanel>
-              </AccordionItem>
-            </Accordion>
-          )}
-        </Box>
-      )}
-    </Box>
-  );
+							<AccordionItem
+								mt={4}
+								borderColor={
+									colorMode === "light"
+										? "blackAlpha.500"
+										: "whiteAlpha.600"
+								}
+								borderBottom={"none"}
+								borderTop={"none"}
+								zIndex={999}
+								opacity={1.5}
+								w={"100%"}
+							>
+								<AccordionButton
+									// bg={colorMode === "light" ? "gray.200" : "gray.700"}
+									bg={
+										colorMode === "light"
+											? "green.500"
+											: "green.600"
+									}
+									w={"100%"}
+									color={"white"}
+									_hover={
+										colorMode === "light"
+											? { bg: "green.400" }
+											: { bg: "green.500" }
+									}
+									userSelect={"none"}
+									opacity={0.9}
+									borderBottomRadius={"50%"}
+									alignItems={"center"}
+									justifyContent={"center"}
+								>
+									<Center mb={4} mt={4} ml={6}>
+										<Box
+											display="flex"
+											alignItems="center"
+											justifyContent="center"
+											width={8}
+											height={8}
+											mr={4}
+										>
+											<MdScience size={"lg"} />
+										</Box>
+										<Text
+											fontWeight={"bold"}
+											fontSize={"xl"}
+											// color={"black"}
+										>
+											Progress Reports (
+											{latestProgressReportsData?.length})
+										</Text>
+									</Center>
+								</AccordionButton>
+								<AccordionPanel py={4} mt={4}>
+									{latestProgressReportsData &&
+										latestProgressReportsData?.map(
+											(pr, index) => {
+												return (
+													<ARProgressReportHandler
+														key={`ordinary${index}`}
+														canEdit={
+															userData?.is_superuser ||
+															userData
+																?.business_area
+																?.name ===
+																"Directorate"
+														}
+														report={pr}
+														shouldAlternatePicture={
+															index % 2 !== 0
+														}
+													/>
+												);
+											}
+										)}
+								</AccordionPanel>
+							</AccordionItem>
+						</Accordion>
+					)}
+				</Box>
+			)}
+		</Box>
+	);
 };
 
 {
-  /* // <Center>
+	/* // <Center>
         //   {!userLoading &&
         //     latestProgressReportsData?.map((report, index) => {
         //       return (

--- a/src/components/RichTextEditor/Editors/ARStudentReportHandler.tsx
+++ b/src/components/RichTextEditor/Editors/ARStudentReportHandler.tsx
@@ -15,204 +15,219 @@ import { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
 import { SREditor } from "./SREditor";
 
 export interface IStudentReportDisplayData {
-  pk?: number;
-  id?: number;
-  progress_report: string;
-  year: number;
-  team_members: IProjectMember[];
-  report: IReport;
-  document: IMainDoc;
-  project: IProjectData;
+	pk?: number;
+	id?: number;
+	progress_report: string;
+	year: number;
+	team_members: IProjectMember[];
+	report: IReport;
+	document: IMainDoc;
+	project: IProjectData;
 }
 
 interface IProps {
-  canEdit: boolean;
-  // report: IReport;
-  report: IStudentReportDisplayData;
-  shouldAlternatePicture: boolean;
+	canEdit: boolean;
+	// report: IReport;
+	report: IStudentReportDisplayData;
+	shouldAlternatePicture: boolean;
 }
 
 export const ARStudentReportHandler = ({
-  canEdit,
-  report,
-  shouldAlternatePicture,
+	canEdit,
+	report,
+	shouldAlternatePicture,
 }: IProps) => {
-  // useEffect(() => console.log(report))
-  const { colorMode } = useColorMode();
+	// useEffect(() => console.log(report))
+	const { colorMode } = useColorMode();
 
-  const generateTheme = (colorMode) => {
-    return {
-      quote: "editor-quote",
-      ltr: "ltr",
-      rtl: "rtl",
-      paragraph: colorMode === "light" ? "editor-p-light" : "editor-p-dark",
-      span: colorMode === "light" ? "editor-p-light" : "editor-p-dark",
-      heading: {
-        h1: colorMode === "light" ? "editor-h1-light" : "editor-h1-dark",
-        h2: colorMode === "light" ? "editor-h2-light" : "editor-h2-dark",
-        h3: colorMode === "light" ? "editor-h3-light" : "editor-h3-dark",
-      },
-      list: {
-        ul: colorMode === "light" ? "editor-ul-light" : "editor-ul-dark",
-        ol: colorMode === "light" ? "editor-ol-light" : "editor-ol-dark",
-        listitem: colorMode === "light" ? "editor-li-light" : "editor-li-dark",
-        listitemChecked: "editor-list-item-checked",
-        listitemUnchecked: "editor-list-item-unchecked",
-        nested: {
-          listitem: "editor-nested-list-item",
-        },
-        // Handling styling for each level of list nesting (1st is default styling)
-        ulDepth: ["editor-ul1", "editor-ul2", "editor-ul3"],
-        olDepth: ["editor-ol1", "editor-ol2", "editor-ol3"],
-      },
-      text: {
-        bold: colorMode === "light" ? "editor-bold-light" : "editor-bold-dark",
-        italic:
-          colorMode === "light"
-            ? "editor-italics-light"
-            : "editor-italics-dark",
-        underline:
-          colorMode === "light"
-            ? "editor-underline-light"
-            : "editor-underline-dark",
-        strikethrough:
-          colorMode === "light"
-            ? "editor-textStrikethrough-light"
-            : "editor-textStrikethrough-dark",
-        subscript:
-          colorMode === "light"
-            ? "editor-textSubscript-light"
-            : "editor-textSubscript-dark",
-        underlineStrikethrough:
-          colorMode === "light"
-            ? "editor-textUnderlineStrikethrough-light"
-            : "editor-textUnderlineStrikethrough-dark",
-      },
-      table: colorMode === "light" ? "table-light" : "table-dark",
-      tableAddColumns:
-        colorMode === "light"
-          ? "table-add-columns-light"
-          : "table-add-columns-dark",
-      tableAddRows:
-        colorMode === "light" ? "table-add-rows-light" : "table-add-rows-dark",
-      tableCell: colorMode === "light" ? "table-cell-light" : "table-cell-dark",
-      tableCellActionButton:
-        colorMode === "light"
-          ? "table-action-button-light"
-          : "table-action-button-dark",
-      tableCellActionButtonContainer:
-        colorMode === "light"
-          ? "table-action-button-container-light"
-          : "table-action-button-container-dark",
-      tableCellEditing:
-        colorMode === "light"
-          ? "table-cell-editing-light"
-          : "table-cell-editing-dark",
-      tableCellHeader:
-        colorMode === "light"
-          ? "table-cell-header-light"
-          : "table-cell-header-dark",
-      tableCellPrimarySelected:
-        colorMode === "light"
-          ? "table-cell-primary-selected-light"
-          : "table-cell-primary-selected-dark",
-      tableCellResizer:
-        colorMode === "light"
-          ? "table-cell-resizer-light"
-          : "table-cell-resizer-dark",
-      tableCellSelected:
-        colorMode === "light"
-          ? "table-cell-selected-light"
-          : "table-cell-selected-dark",
-      tableCellSortedIndicator:
-        colorMode === "light"
-          ? "table-cell-sorted-indicator-light"
-          : "table-cell-sorted-indicator-dark",
-      tableResizeRuler:
-        colorMode === "light"
-          ? "table-cell-resize-ruler-light"
-          : "table-cell-resize-ruler-dark",
-      tableSelected:
-        colorMode === "light" ? "table-selected-light" : "table-selected-dark",
-      tableSelection:
-        colorMode === "light"
-          ? "table-selection-light"
-          : "table-selection-dark",
-    };
-  };
-  const theme = generateTheme(colorMode);
+	const generateTheme = (colorMode) => {
+		return {
+			quote: "editor-quote",
+			ltr: "ltr",
+			rtl: "rtl",
+			paragraph:
+				colorMode === "light" ? "editor-p-light" : "editor-p-dark",
+			span: colorMode === "light" ? "editor-p-light" : "editor-p-dark",
+			heading: {
+				h1:
+					colorMode === "light"
+						? "editor-h1-light"
+						: "editor-h1-dark",
+				h2:
+					colorMode === "light"
+						? "editor-h2-light"
+						: "editor-h2-dark",
+				h3:
+					colorMode === "light"
+						? "editor-h3-light"
+						: "editor-h3-dark",
+			},
+			list: {
+				ul:
+					colorMode === "light"
+						? "editor-ul-light"
+						: "editor-ul-dark",
+				ol:
+					colorMode === "light"
+						? "editor-ol-light"
+						: "editor-ol-dark",
+				listitem:
+					colorMode === "light"
+						? "editor-li-light"
+						: "editor-li-dark",
+				listitemChecked: "editor-list-item-checked",
+				listitemUnchecked: "editor-list-item-unchecked",
+				nested: {
+					listitem: "editor-nested-list-item",
+				},
+				// Handling styling for each level of list nesting (1st is default styling)
+				ulDepth: ["editor-ul1", "editor-ul2", "editor-ul3"],
+				olDepth: ["editor-ol1", "editor-ol2", "editor-ol3"],
+			},
+			text: {
+				bold:
+					colorMode === "light"
+						? "editor-bold-light"
+						: "editor-bold-dark",
+				italic:
+					colorMode === "light"
+						? "editor-italics-light"
+						: "editor-italics-dark",
+				underline:
+					colorMode === "light"
+						? "editor-underline-light"
+						: "editor-underline-dark",
+				strikethrough:
+					colorMode === "light"
+						? "editor-textStrikethrough-light"
+						: "editor-textStrikethrough-dark",
+				subscript:
+					colorMode === "light"
+						? "editor-textSubscript-light"
+						: "editor-textSubscript-dark",
+				underlineStrikethrough:
+					colorMode === "light"
+						? "editor-textUnderlineStrikethrough-light"
+						: "editor-textUnderlineStrikethrough-dark",
+			},
+			table: colorMode === "light" ? "table-light" : "table-dark",
+			tableAddColumns:
+				colorMode === "light"
+					? "table-add-columns-light"
+					: "table-add-columns-dark",
+			tableAddRows:
+				colorMode === "light"
+					? "table-add-rows-light"
+					: "table-add-rows-dark",
+			tableCell:
+				colorMode === "light" ? "table-cell-light" : "table-cell-dark",
+			tableCellActionButton:
+				colorMode === "light"
+					? "table-action-button-light"
+					: "table-action-button-dark",
+			tableCellActionButtonContainer:
+				colorMode === "light"
+					? "table-action-button-container-light"
+					: "table-action-button-container-dark",
+			tableCellEditing:
+				colorMode === "light"
+					? "table-cell-editing-light"
+					: "table-cell-editing-dark",
+			tableCellHeader:
+				colorMode === "light"
+					? "table-cell-header-light"
+					: "table-cell-header-dark",
+			tableCellPrimarySelected:
+				colorMode === "light"
+					? "table-cell-primary-selected-light"
+					: "table-cell-primary-selected-dark",
+			tableCellResizer:
+				colorMode === "light"
+					? "table-cell-resizer-light"
+					: "table-cell-resizer-dark",
+			tableCellSelected:
+				colorMode === "light"
+					? "table-cell-selected-light"
+					: "table-cell-selected-dark",
+			tableCellSortedIndicator:
+				colorMode === "light"
+					? "table-cell-sorted-indicator-light"
+					: "table-cell-sorted-indicator-dark",
+			tableResizeRuler:
+				colorMode === "light"
+					? "table-cell-resize-ruler-light"
+					: "table-cell-resize-ruler-dark",
+			tableSelected:
+				colorMode === "light"
+					? "table-selected-light"
+					: "table-selected-dark",
+			tableSelection:
+				colorMode === "light"
+					? "table-selection-light"
+					: "table-selection-dark",
+		};
+	};
+	const theme = generateTheme(colorMode);
 
-  const onError = (error: Error) => {
-    console.log(error);
-  };
+	const onError = (error: Error) => {
+		console.log(error);
+	};
 
-  const initialConfig = {
-    namespace: `Student Report Editor`,
-    editable: true,
-    theme,
-    onError,
-    nodes: [ListNode, ListItemNode, TableCellNode, TableNode, TableRowNode],
-  };
+	const initialConfig = {
+		namespace: `Student Report Editor`,
+		editable: true,
+		theme,
+		onError,
+		nodes: [ListNode, ListItemNode, TableCellNode, TableNode, TableRowNode],
+	};
 
-  const uneditableInitialConfig = {
-    ...initialConfig,
-    editable: false,
-    theme: generateTheme(colorMode),
-  };
+	const uneditableInitialConfig = {
+		...initialConfig,
+		editable: false,
+		theme: generateTheme(colorMode),
+	};
 
-  // const [editorText, setEditorText] = useState<string | null>("");
-  const [isEditing, setIsEditing] = useState(false);
-  const [displayData, setDisplayData] = useState(report?.progress_report);
+	// const [editorText, setEditorText] = useState<string | null>("");
+	const [isEditing, setIsEditing] = useState(false);
+	const [displayData, setDisplayData] = useState(report?.progress_report);
 
-  return canEdit ? (
-    isEditing ? (
-      <SREditor
-        key={`${colorMode}-${report?.pk ? report.pk : report?.id}-editable`}
-        canEdit={canEdit}
-        setIsEditing={setIsEditing}
-        isEditing={isEditing}
-        shouldAlternatePicture={shouldAlternatePicture}
-        fullSRData={report}
-        initialConfig={initialConfig}
-        displayData={displayData}
-        setDisplayData={setDisplayData}
-      />
-    ) : (
-      <SREditor
-        key={`${colorMode}-${report?.pk}-uneditable`}
-        canEdit={canEdit}
-        setIsEditing={setIsEditing}
-        isEditing={isEditing}
-        shouldAlternatePicture={shouldAlternatePicture}
-        fullSRData={report}
-        initialConfig={uneditableInitialConfig}
-        displayData={displayData}
-        setDisplayData={setDisplayData}
-      />
-    )
-  ) : (
-    <SREditor
-      key={`${colorMode}-${report?.pk}-uneditable`}
-      canEdit={false}
-      setIsEditing={setIsEditing}
-      isEditing={isEditing}
-      shouldAlternatePicture={shouldAlternatePicture}
-      fullSRData={report}
-      initialConfig={uneditableInitialConfig}
-      displayData={displayData}
-      setDisplayData={setDisplayData}
-    />
-  );
+	return canEdit ? (
+		isEditing ? (
+			<SREditor
+				key={`${colorMode}-${report?.pk ? report.pk : report?.id}-editable`}
+				canEdit={canEdit}
+				setIsEditing={setIsEditing}
+				isEditing={isEditing}
+				shouldAlternatePicture={shouldAlternatePicture}
+				fullSRData={report}
+				initialConfig={initialConfig}
+				displayData={displayData}
+				setDisplayData={setDisplayData}
+			/>
+		) : (
+			<SREditor
+				key={`${colorMode}-${report?.pk}-uneditable`}
+				canEdit={canEdit}
+				setIsEditing={setIsEditing}
+				isEditing={isEditing}
+				shouldAlternatePicture={shouldAlternatePicture}
+				fullSRData={report}
+				initialConfig={uneditableInitialConfig}
+				displayData={displayData}
+				setDisplayData={setDisplayData}
+			/>
+		)
+	) : (
+		<SREditor
+			key={`${colorMode}-${report?.pk}-uneditable`}
+			canEdit={false}
+			setIsEditing={setIsEditing}
+			isEditing={isEditing}
+			shouldAlternatePicture={shouldAlternatePicture}
+			fullSRData={report}
+			initialConfig={uneditableInitialConfig}
+			displayData={displayData}
+			setDisplayData={setDisplayData}
+		/>
+	);
 };
-
-{
-  /* ) : (
-          <DisplaySRTE
-            key={prepopulationData}
-            initialConfig={uneditableInitialCOnfig}
-            data={prepopulationData}
-            section={section}
-            shouldShowTree={shouldShowTree}
-          />
-        )} */
-}

--- a/src/components/RichTextEditor/Editors/PREditor.tsx
+++ b/src/components/RichTextEditor/Editors/PREditor.tsx
@@ -1,26 +1,26 @@
 import { ExtractedHTMLTitle } from "@/components/ExtractedHTMLTitle";
 import {
-  ISaveProgressReportSection,
-  updateProgressReportSection,
+	ISaveProgressReportSection,
+	updateProgressReportSection,
 } from "@/lib/api";
 import { IProjectData, IProjectMember } from "@/types";
 import {
-  Box,
-  Button,
-  Flex,
-  Icon,
-  Image,
-  Text,
-  ToastId,
-  useColorMode,
-  useDisclosure,
-  useToast,
+	Box,
+	Button,
+	Flex,
+	Icon,
+	Image,
+	Text,
+	ToastId,
+	useColorMode,
+	useDisclosure,
+	useToast,
 } from "@chakra-ui/react";
 import { $generateHtmlFromNodes } from "@lexical/html";
 import { AutoFocusPlugin } from "@lexical/react/LexicalAutoFocusPlugin";
 import {
-  InitialConfigType,
-  LexicalComposer,
+	InitialConfigType,
+	LexicalComposer,
 } from "@lexical/react/LexicalComposer";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import LexicalErrorBoundary from "@lexical/react/LexicalErrorBoundary";
@@ -47,1588 +47,1846 @@ import { TiTick } from "react-icons/ti";
 import { useNoImage } from "@/lib/hooks/helper/useNoImage";
 
 interface IPREditorProps {
-  // isEditing: boolean;
-  // setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
+	// isEditing: boolean;
+	// setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
 
-  isEditingContext: boolean;
-  setIsEditingContext: React.Dispatch<React.SetStateAction<boolean>>;
-  isEditingAims: boolean;
-  setIsEditingAims: React.Dispatch<React.SetStateAction<boolean>>;
-  isEditingProgress: boolean;
-  setIsEditingProgress: React.Dispatch<React.SetStateAction<boolean>>;
-  isEditingImplications: boolean;
-  setIsEditingImplications: React.Dispatch<React.SetStateAction<boolean>>;
-  isEditingFuture: boolean;
-  setIsEditingFuture: React.Dispatch<React.SetStateAction<boolean>>;
+	isEditingContext: boolean;
+	setIsEditingContext: React.Dispatch<React.SetStateAction<boolean>>;
+	isEditingAims: boolean;
+	setIsEditingAims: React.Dispatch<React.SetStateAction<boolean>>;
+	isEditingProgress: boolean;
+	setIsEditingProgress: React.Dispatch<React.SetStateAction<boolean>>;
+	isEditingImplications: boolean;
+	setIsEditingImplications: React.Dispatch<React.SetStateAction<boolean>>;
+	isEditingFuture: boolean;
+	setIsEditingFuture: React.Dispatch<React.SetStateAction<boolean>>;
 
-  canEdit: boolean;
-  shouldAlternatePicture: boolean;
-  fullPRData: IProgressReportDisplayData;
+	canEdit: boolean;
+	shouldAlternatePicture: boolean;
+	fullPRData: IProgressReportDisplayData;
 
-  editableInitialConfig: InitialConfigType;
-  uneditableInitialConfig: InitialConfigType;
+	editableInitialConfig: InitialConfigType;
+	uneditableInitialConfig: InitialConfigType;
 
-  contextDisplayData: string;
-  setContextDisplayData: React.Dispatch<React.SetStateAction<string>>;
+	contextDisplayData: string;
+	setContextDisplayData: React.Dispatch<React.SetStateAction<string>>;
 
-  aimsDisplayData: string;
-  setAimsDisplayData: React.Dispatch<React.SetStateAction<string>>;
+	aimsDisplayData: string;
+	setAimsDisplayData: React.Dispatch<React.SetStateAction<string>>;
 
-  progressReportDisplayData: string;
-  setProgressReportDisplayData: React.Dispatch<React.SetStateAction<string>>;
+	progressReportDisplayData: string;
+	setProgressReportDisplayData: React.Dispatch<React.SetStateAction<string>>;
 
-  managementImplicationsDisplayData: string;
-  setManagementImplicationsDisplayData: React.Dispatch<
-    React.SetStateAction<string>
-  >;
+	managementImplicationsDisplayData: string;
+	setManagementImplicationsDisplayData: React.Dispatch<
+		React.SetStateAction<string>
+	>;
 
-  futureDirectionsDisplayData: string;
-  setFutureDirectionsDisplayData: React.Dispatch<React.SetStateAction<string>>;
+	futureDirectionsDisplayData: string;
+	setFutureDirectionsDisplayData: React.Dispatch<
+		React.SetStateAction<string>
+	>;
 
-  // key: string;
+	// key: string;
 }
 
 interface IPRProjDetails {
-  project: IProjectData;
-  team_members: IProjectMember[];
+	project: IProjectData;
+	team_members: IProjectMember[];
 }
 const PRProjDetails = ({ project, team_members }: IPRProjDetails) => {
-  const getOrderedTeam = (teamMembers) => {
-    return Array.from(teamMembers)
-      .sort((a: IProjectMember, b: IProjectMember) => {
-        // Prioritize members with is_leader = true
-        if (a.is_leader && !b.is_leader) {
-          return -1;
-        } else if (!a.is_leader && b.is_leader) {
-          return 1;
-        } else {
-          // If both have the same is_leader status, sort by position
-          return a.position - b.position;
-        }
-      })
-      .map(
-        (member: IProjectMember) =>
-          `${member.user.first_name} ${member.user.last_name}`
-      );
-  };
+	const getOrderedTeam = (teamMembers) => {
+		return Array.from(teamMembers)
+			.sort((a: IProjectMember, b: IProjectMember) => {
+				// Prioritize members with is_leader = true
+				if (a.is_leader && !b.is_leader) {
+					return -1;
+				} else if (!a.is_leader && b.is_leader) {
+					return 1;
+				} else {
+					// If both have the same is_leader status, sort by position
+					return a.position - b.position;
+				}
+			})
+			.map(
+				(member: IProjectMember) =>
+					`${member.user.first_name} ${member.user.last_name}`
+			);
+	};
 
-  const orderedTeam = getOrderedTeam(team_members);
+	const orderedTeam = getOrderedTeam(team_members);
 
-  return (
-    <Box py={3}>
-      <Flex mb={0.5} flexWrap={"wrap"}>
-        <Text fontWeight={"semibold"} mr={1}>
-          Tag:{" "}
-        </Text>
-        <Text>{`STP-${project?.year}-${project?.number}`}</Text>
-      </Flex>
-      <Flex mb={0.5} flexWrap={"wrap"}>
-        <Text fontWeight={"semibold"} mr={1}>
-          Scientists:{" "}
-        </Text>
-        <Text>{orderedTeam.join(", ")}</Text>
-      </Flex>
-    </Box>
-  );
+	return (
+		<Box py={3}>
+			<Flex mb={0.5} flexWrap={"wrap"}>
+				<Text
+					fontWeight={"semibold"}
+					mr={1}
+					color={
+						project?.status === "completed" ||
+						project?.status === "terminated"
+							? "green.500"
+							: project?.status === "updating"
+								? "red.500"
+								: project?.status === "suspended"
+									? "orange.500"
+									: undefined
+					}
+				>
+					Status:{" "}
+				</Text>
+				<Text
+					color={
+						project?.status === "completed" ||
+						project?.status === "terminated"
+							? "green.500"
+							: project?.status === "updating"
+								? "red.500"
+								: project?.status === "suspended"
+									? "orange.500"
+									: undefined
+					}
+				>
+					{`${project?.status[0].toUpperCase()}${project?.status.slice(1)}`}
+				</Text>
+			</Flex>
+			<Flex mb={0.5} flexWrap={"wrap"}>
+				<Text fontWeight={"semibold"} mr={1}>
+					Tag:{" "}
+				</Text>
+				<Text>{`${project.kind === "science" ? "SP" : project.kind === "external" ? "EXT" : "CF"}-${project?.year}-${project?.number}`}</Text>
+			</Flex>
+			<Flex mb={0.5} flexWrap={"wrap"}>
+				<Text fontWeight={"semibold"} mr={1}>
+					Scientists:{" "}
+				</Text>
+				<Text>{orderedTeam.join(", ")}</Text>
+			</Flex>
+		</Box>
+	);
 };
 
 export const PREditor = ({
-  shouldAlternatePicture,
-  fullPRData,
-  editableInitialConfig,
-  uneditableInitialConfig,
-  canEdit,
-  isEditingContext,
-  setIsEditingContext,
-  isEditingAims,
-  setIsEditingAims,
-  isEditingProgress,
-  setIsEditingProgress,
-  isEditingImplications,
-  setIsEditingImplications,
-  isEditingFuture,
-  setIsEditingFuture,
-  aimsDisplayData,
-  progressReportDisplayData,
-  managementImplicationsDisplayData,
-  futureDirectionsDisplayData,
-  contextDisplayData,
-  setAimsDisplayData,
-  setProgressReportDisplayData,
-  setManagementImplicationsDisplayData,
-  setFutureDirectionsDisplayData,
-  setContextDisplayData,
+	shouldAlternatePicture,
+	fullPRData,
+	editableInitialConfig,
+	uneditableInitialConfig,
+	canEdit,
+	isEditingContext,
+	setIsEditingContext,
+	isEditingAims,
+	setIsEditingAims,
+	isEditingProgress,
+	setIsEditingProgress,
+	isEditingImplications,
+	setIsEditingImplications,
+	isEditingFuture,
+	setIsEditingFuture,
+	aimsDisplayData,
+	progressReportDisplayData,
+	managementImplicationsDisplayData,
+	futureDirectionsDisplayData,
+	contextDisplayData,
+	setAimsDisplayData,
+	setProgressReportDisplayData,
+	setManagementImplicationsDisplayData,
+	setFutureDirectionsDisplayData,
+	setContextDisplayData,
 }: // key
 IPREditorProps) => {
-  // const navigate = useNavigate();
-  const { colorMode } = useColorMode();
-
-  // const editorInstance = useLexicalComposerContext();
-
-  // useEffect(() => {
-
-  //     if (editorInstance) {
-  //       // Perform operations on the Lexical editor instance
-  //       const root = editorInstance.$getRoot();
-  //       setEditorText(root.__cachedText);
-  //     }
-  //   }, [editorRef, setEditorText]);
-
-  const dragBtnMargin = 10;
-  const toolBarHeight = 45;
-  const [aboveHeightSet, setAboveHeightSet] = useState<boolean>(false);
-  const [aboveContentHeight, setAboveContentHeight] = useState<number>();
-
-  // const [htmlData, setHtmlData] = useState(fullSRData?.progress_report);
-
-  // Mouse Over and Out each editor
-  const [isHoveredContext, setIsHoveredContext] = useState(false);
-  const [isHoveredAims, setIsHoveredAims] = useState(false);
-  const [isHoveredProgress, setIsHoveredProgress] = useState(false);
-  const [isHoveredImplications, setIsHoveredImplications] = useState(false);
-  const [isHoveredFuture, setIsHoveredFuture] = useState(false);
-
-  const onMouseOverContext = () => {
-    if (!isHoveredContext) {
-      setIsHoveredContext(true);
-    }
-  };
-
-  const onMouseOutContext = () => {
-    if (isHoveredContext) {
-      setIsHoveredContext(false);
-    }
-  };
-
-  const onMouseOverAims = () => {
-    if (!isHoveredAims) {
-      setIsHoveredAims(true);
-    }
-  };
-
-  const onMouseOutAims = () => {
-    if (isHoveredAims) {
-      setIsHoveredAims(false);
-    }
-  };
-  const onMouseOverProgress = () => {
-    if (!isHoveredProgress) {
-      setIsHoveredProgress(true);
-    }
-  };
-
-  const onMouseOutProgress = () => {
-    if (isHoveredProgress) {
-      setIsHoveredProgress(false);
-    }
-  };
-  const onMouseOverImplications = () => {
-    if (!isHoveredImplications) {
-      setIsHoveredImplications(true);
-    }
-  };
-
-  const onMouseOutImplications = () => {
-    if (isHoveredImplications) {
-      setIsHoveredImplications(false);
-    }
-  };
-  const onMouseOverFuture = () => {
-    if (!isHoveredFuture) {
-      setIsHoveredFuture(true);
-    }
-  };
-
-  const onMouseOutFuture = () => {
-    if (isHoveredFuture) {
-      setIsHoveredFuture(false);
-    }
-  };
-
-  // useEffect(() => {
-  //     setAboveHeightSet(false);
-  //     const calculateAboveContentHeight = () => {
-  //         const aboveContentElement = document.getElementById(`topContent_${fullPRData?.project?.pk}`);
-
-  //         if (aboveContentElement) {
-  //             const rect = aboveContentElement.getBoundingClientRect();
-  //             const contentAboveHeight = rect.bottom - rect.top;
-  //             setAboveContentHeight(contentAboveHeight);
-  //         }
-  //     };
-
-  //     // Call the function initially
-  //     calculateAboveContentHeight();
-
-  //     // Attach resize event listener to recalculate height when the window is resized
-  //     window.addEventListener('resize', calculateAboveContentHeight);
-  //     setAboveHeightSet(true);
-
-  //     // Cleanup event listener on component unmount
-  //     return () => {
-  //         window.removeEventListener('resize', calculateAboveContentHeight);
-  //     };
-  // }, [displayData, isEditing, fullPRData?.project?.pk, initialConfig]);
-
-  const queryClient = useQueryClient();
-  const { register, handleSubmit, reset } =
-    useForm<ISaveProgressReportSection>();
-  const toast = useToast();
-  const toastIdRef = useRef<ToastId>();
-  const addToast = (data) => {
-    toastIdRef.current = toast(data);
-  };
-
-  const saveMutation = useMutation({
-    mutationFn: updateProgressReportSection,
-    onMutate: () => {
-      addToast({
-        status: "loading",
-        title: "Updating Progress Report",
-        position: "top-right",
-      });
-    },
-    onSuccess: () => {
-      if (toastIdRef.current) {
-        toast.update(toastIdRef.current, {
-          title: "Success",
-          description: `Progress Report Updated`,
-          status: "success",
-          position: "top-right",
-          duration: 3000,
-          isClosable: true,
-        });
-      }
-      // reset();
-
-      // setTimeout(() => {
-      //   queryClient.invalidateQueries(["mytasks"]);
-      // }, 350);
-    },
-    onError: (error) => {
-      if (toastIdRef.current) {
-        toast.update(toastIdRef.current, {
-          title: "Could Not Update Progress Report",
-          description: `${error}`,
-          status: "error",
-          position: "top-right",
-          duration: 3000,
-          isClosable: true,
-        });
-      }
-    },
-  });
-
-  const onSave = (formData: ISaveProgressReportSection) => {
-    const section = formData.section;
-
-    saveMutation.mutate(formData);
-    if (section === "context") {
-      setIsEditingContext(false);
-    } else if (section === "aims") {
-      setIsEditingAims(false);
-    } else if (section === "progress") {
-      setIsEditingProgress(false);
-    } else if (section === "implications") {
-      setIsEditingImplications(false);
-    } else if (section === "future") {
-      setIsEditingFuture(false);
-    }
-  };
-
-  const [initialConfigFuture, setInitialConfigFuture] =
-    useState<InitialConfigType>(uneditableInitialConfig);
-  const [initialConfigImplications, setInitialConfigImplications] =
-    useState<InitialConfigType>(uneditableInitialConfig);
-  const [initialConfigProgress, setInitialConfigProgress] =
-    useState<InitialConfigType>(uneditableInitialConfig);
-  const [initialConfigAims, setInitialConfigAims] = useState<InitialConfigType>(
-    uneditableInitialConfig
-  );
-  const [initialConfigContext, setInitialConfigContext] =
-    useState<InitialConfigType>(uneditableInitialConfig);
-
-  useEffect(() => {
-    if (isEditingContext) {
-      if (initialConfigContext.editable === false) {
-        setInitialConfigContext(editableInitialConfig);
-      }
-    } else {
-      if (initialConfigContext.editable === true) {
-        setInitialConfigContext(uneditableInitialConfig);
-      }
-    }
-  }, [
-    initialConfigContext,
-    isEditingContext,
-    editableInitialConfig,
-    uneditableInitialConfig,
-  ]);
-
-  useEffect(() => {
-    if (isEditingAims) {
-      if (initialConfigAims.editable === false) {
-        setInitialConfigAims(editableInitialConfig);
-      }
-    } else {
-      if (initialConfigAims.editable === true) {
-        setInitialConfigAims(uneditableInitialConfig);
-      }
-    }
-  }, [
-    initialConfigAims,
-    isEditingAims,
-    editableInitialConfig,
-    uneditableInitialConfig,
-  ]);
-
-  useEffect(() => {
-    if (isEditingProgress) {
-      if (initialConfigProgress.editable === false) {
-        setInitialConfigProgress(editableInitialConfig);
-      }
-    } else {
-      if (initialConfigProgress.editable === true) {
-        setInitialConfigProgress(uneditableInitialConfig);
-      }
-    }
-  }, [
-    initialConfigProgress,
-    isEditingProgress,
-    editableInitialConfig,
-    uneditableInitialConfig,
-  ]);
-
-  useEffect(() => {
-    if (initialConfigFuture.editable === false) {
-      if (isEditingFuture) {
-        setInitialConfigFuture(editableInitialConfig);
-      }
-    } else if (initialConfigFuture.editable === true) {
-      if (!isEditingFuture) {
-        setInitialConfigFuture(uneditableInitialConfig);
-      }
-    }
-  }, [
-    initialConfigFuture,
-    isEditingFuture,
-    editableInitialConfig,
-    uneditableInitialConfig,
-  ]);
-
-  useEffect(() => {
-    if (initialConfigImplications.editable === false) {
-      if (isEditingImplications) {
-        setInitialConfigImplications(editableInitialConfig);
-      }
-    } else if (initialConfigImplications.editable === true) {
-      if (!isEditingImplications) {
-        setInitialConfigImplications(uneditableInitialConfig);
-      }
-    }
-  }, [
-    initialConfigImplications,
-    isEditingImplications,
-    editableInitialConfig,
-    uneditableInitialConfig,
-  ]);
-
-  const {
-    isOpen: isApproveProgressReportOpen,
-    onOpen: onOpenApproveProgressReport,
-    onClose: onCloseApproveProgressReport,
-  } = useDisclosure();
-  const [reportHovered, setReportHovered] = useState(false);
-  const [isActive, setIsActive] = useState(
-    fullPRData?.document?.project?.status === "active"
-  );
-  useEffect(() => {
-    setIsActive(fullPRData?.document?.project?.status === "active");
-  }, [fullPRData]);
-
-  const noImage = useNoImage();
-
-  return (
-    <>
-      {/* setIsEditing */}
-      <ApproveProgressReportModal
-        isActive={isActive}
-        report={fullPRData}
-        isOpen={isApproveProgressReportOpen}
-        onClose={onCloseApproveProgressReport}
-      />
-      <Box
-        mx={4}
-        pos={"relative"}
-        roundedBottom={20}
-        roundedTop={20}
-        mb={4}
-        boxShadow={
-          "0 8px 24px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.1)"
-        }
-        bg={colorMode === "light" ? "whiteAlpha.600" : "blackAlpha.500"}
-        onMouseOver={() => setReportHovered(true)}
-        onMouseOut={() => setReportHovered(false)}
-      >
-        {reportHovered ? (
-          <Box pos={"absolute"} right={4} top={4}>
-            <Button
-              ml={2}
-              bg={
-                isActive
-                  ? colorMode === "light"
-                    ? `orange.500`
-                    : `orange.600`
-                  : colorMode === "light"
-                  ? `green.500`
-                  : `green.600`
-              }
-              color={
-                colorMode === "light" ? "whiteAlpha.900" : "whiteAlpha.800"
-              }
-              _hover={
-                colorMode === "light"
-                  ? {
-                      bg: isActive ? `orange.600` : `green.600`,
-                      color: `white`,
-                    }
-                  : {
-                      bg: isActive ? `orange.500` : `green.500`,
-                      color: `white`,
-                    }
-              }
-              minW={"32px"}
-              minH={"32px"}
-              maxW={"32px"}
-              maxH={"32px"}
-              rounded={"full"}
-              data-tip="Click to edit"
-              onClick={onOpenApproveProgressReport}
-            >
-              <Icon as={isActive ? FaUndo : TiTick} />
-            </Button>
-          </Box>
-        ) : null}
-
-        <Flex
-          id={`topContent_${fullPRData?.document?.project?.pk}`}
-          pt={6}
-          mx={8}
-        >
-          {!shouldAlternatePicture ? (
-            <>
-              <Box rounded={"md"} overflow={"hidden"} w={"276px"} h={"200px"}>
-                <Image
-                  src={fullPRData?.document?.project?.image?.file ?? noImage}
-                  w={"100%"}
-                  h={"100%"}
-                  objectFit={"cover"}
-                />
-              </Box>
-              <Box ml={4} flex={1}>
-                <Box>
-                  <ExtractedHTMLTitle
-                    htmlContent={fullPRData?.document?.project?.title}
-                    color={"blue.500"}
-                    fontWeight={"bold"}
-                    fontSize={"17px"}
-                    // fontSize={"xs"}
-                    noOfLines={4}
-                    cursor={"pointer"}
-                    onClick={() => {
-                      const url = `/projects/${fullPRData?.document?.project?.pk}/progress`;
-                      window.open(url, "_blank");
-                      // navigate(url);
-                    }}
-                  />
-                </Box>
-
-                <PRProjDetails
-                  project={fullPRData?.document?.project}
-                  team_members={fullPRData?.team_members}
-                />
-              </Box>
-            </>
-          ) : (
-            <>
-              <Box mr={4} flex={1}>
-                <Box>
-                  <ExtractedHTMLTitle
-                    htmlContent={fullPRData?.document?.project?.title}
-                    color={"blue.500"}
-                    fontWeight={"bold"}
-                    fontSize={"17px"}
-                    // fontSize={"xs"}
-                    cursor={"pointer"}
-                    onClick={() => {
-                      const url = `/projects/${fullPRData?.document?.project?.pk}/progress`;
-                      window.open(url, "_blank");
-                      // navigate(url);
-                    }}
-                    noOfLines={4}
-                  />
-                </Box>
-
-                <PRProjDetails
-                  project={fullPRData?.document?.project}
-                  team_members={fullPRData?.team_members}
-                />
-              </Box>
-              <Box rounded={"md"} overflow={"hidden"} w={"276px"} h={"200px"}>
-                <Image
-                  src={fullPRData?.document?.project?.image?.file ?? noImage}
-                  w={"100%"}
-                  h={"100%"}
-                  objectFit={"cover"}
-                />
-              </Box>
-            </>
-          )}
-        </Flex>
-        {/* Context */}
-        <LexicalComposer
-          key={`context-${initialConfigContext.editable}`}
-          initialConfig={initialConfigContext}
-        >
-          {/* Plugins*/}
-          <TablePlugin hasCellMerge={true} hasCellBackgroundColor={false} />
-          <HistoryPlugin />
-          <ListPlugin />
-
-          <OnChangePlugin
-            onChange={(editorState, editor) => {
-              editorState.read(() => {
-                const root = $getRoot();
-
-                // setEditorText(root.__cachedText);
-                const newHtml = $generateHtmlFromNodes(editor, null);
-                // setHtmlData(newHtml);
-                setContextDisplayData(newHtml);
-              });
-            }}
-          />
-          {/* {data !== undefined && data !== null && ( */}
-          <PrepopulateHTMLPlugin data={contextDisplayData} />
-          {/* )} */}
-          <CustomPastePlugin />
-
-          {/* Text Area */}
-          <RichTextPlugin
-            placeholder={<Text></Text>}
-            contentEditable={
-              <Box
-                mt={4}
-                onMouseOver={onMouseOverContext}
-                onMouseLeave={onMouseOutContext}
-                // bg={"red"}
-              >
-                {/* Toolbar */}
-                {isEditingContext === false ? null : <RevisedRichTextToolbar />}
-
-                <Box pos={"relative"}>
-                  <Text
-                    fontWeight={"bold"}
-                    fontSize={"lg"}
-                    px={8}
-                    ml={"2px"}
-                    mt={4}
-                    // userSelect={"none"}
-                  >
-                    Context
-                  </Text>
-
-                  {isEditingContext === true ? (
-                    <Box pos={"absolute"} right={10} top={0}>
-                      <Flex flexDir={"row"}>
-                        <Button
-                          bg={colorMode === "light" ? `green.500` : `green.600`}
-                          color={
-                            colorMode === "light"
-                              ? "whiteAlpha.900"
-                              : "whiteAlpha.800"
-                          }
-                          _hover={
-                            colorMode === "light"
-                              ? {
-                                  bg: `green.600`,
-                                  color: `white`,
-                                }
-                              : {
-                                  bg: `green.500`,
-                                  color: `white`,
-                                }
-                          }
-                          minW={"32px"}
-                          minH={"32px"}
-                          maxW={"32px"}
-                          maxH={"32px"}
-                          rounded={"full"}
-                          data-tip="Click to Save"
-                          onClick={() =>
-                            onSave({
-                              mainDocumentId: fullPRData?.document?.pk,
-                              section: "context",
-                              htmlData: contextDisplayData,
-                            })
-                          }
-                        >
-                          <Icon as={FaSave} />
-                        </Button>
-
-                        <Button
-                          ml={2}
-                          bg={colorMode === "light" ? `gray.500` : `gray.600`}
-                          color={
-                            colorMode === "light"
-                              ? "whiteAlpha.900"
-                              : "whiteAlpha.800"
-                          }
-                          _hover={
-                            colorMode === "light"
-                              ? {
-                                  bg: `gray.600`,
-                                  color: `white`,
-                                }
-                              : {
-                                  bg: `gray.500`,
-                                  color: `white`,
-                                }
-                          }
-                          minW={"32px"}
-                          minH={"32px"}
-                          maxW={"32px"}
-                          maxH={"32px"}
-                          rounded={"full"}
-                          data-tip="Click to Save"
-                          onClick={() => setIsEditingContext(false)}
-                        >
-                          <Icon as={AiFillEyeInvisible} />
-                        </Button>
-                      </Flex>
-                    </Box>
-                  ) : isHoveredContext ? (
-                    <Box pos={"absolute"} right={10} top={0}>
-                      <Button
-                        ml={2}
-                        bg={colorMode === "light" ? `gray.500` : `gray.600`}
-                        color={
-                          colorMode === "light"
-                            ? "whiteAlpha.900"
-                            : "whiteAlpha.800"
-                        }
-                        _hover={
-                          colorMode === "light"
-                            ? {
-                                bg: `gray.600`,
-                                color: `white`,
-                              }
-                            : {
-                                bg: `gray.500`,
-                                color: `white`,
-                              }
-                        }
-                        minW={"32px"}
-                        minH={"32px"}
-                        maxW={"32px"}
-                        maxH={"32px"}
-                        rounded={"full"}
-                        data-tip="Click to Save"
-                        onClick={() => setIsEditingContext(true)}
-                      >
-                        <Icon as={AiFillEdit} />
-                      </Button>
-                    </Box>
-                  ) : null}
-                </Box>
-
-                <Box mt={"-15px"} className="editor-scroller">
-                  <Box
-                    //   className="editor"
-                    //   ref={onRef}
-                    style={{
-                      // background: "red",
-                      marginLeft: `${dragBtnMargin}px`,
-                    }}
-                  >
-                    <ContentEditable
-                      style={{
-                        minHeight: "50px",
-                        width: "100%",
-                        height: "auto",
-                        padding: "32px",
-                        paddingBottom: "16px",
-                        //   borderRadius: "0 0 25px 25px",
-                        outline: "none",
-                        marginLeft: -8,
-                      }}
-
-                      // autoFocus
-                    />
-                  </Box>
-                </Box>
-                {/* <Box>Editor: {editorText}</Box> */}
-              </Box>
-            }
-            // placeholder={
-            //     isEditing ?
-            //         <Box
-            //             style={{
-            //                 position: "absolute",
-            //                 left: `${24 + dragBtnMargin}px`,
-            //                 top: `${75 + aboveContentHeight + toolBarHeight}px`,
-            //                 userSelect: "none",
-            //                 pointerEvents: "none",
-            //                 color: "gray",
-            //             }}
-            //         >
-            //             {`Enter text...`}
-            //         </Box>
-            //         : null
-            // }
-            ErrorBoundary={LexicalErrorBoundary}
-          />
-
-          <TabIndentationPlugin />
-          <ListMaxIndentLevelPlugin maxDepth={3} />
-          <AutoFocusPlugin />
-        </LexicalComposer>
-
-        {/* Aims */}
-        <LexicalComposer
-          key={`aims-${initialConfigAims.editable}`}
-          initialConfig={initialConfigAims}
-        >
-          {/* Plugins*/}
-          <TablePlugin hasCellMerge={true} hasCellBackgroundColor={false} />
-          <HistoryPlugin />
-          <ListPlugin />
-
-          <OnChangePlugin
-            onChange={(editorState, editor) => {
-              editorState.read(() => {
-                const root = $getRoot();
-
-                // setEditorText(root.__cachedText);
-                const newHtml = $generateHtmlFromNodes(editor, null);
-                // setHtmlData(newHtml);
-                setAimsDisplayData(newHtml);
-              });
-            }}
-          />
-          {/* {data !== undefined && data !== null && ( */}
-          <PrepopulateHTMLPlugin data={aimsDisplayData} />
-          {/* )} */}
-          <CustomPastePlugin />
-
-          {/* Text Area */}
-          <RichTextPlugin
-            placeholder={<Text></Text>}
-            contentEditable={
-              <Box
-                mt={4}
-                onMouseOver={onMouseOverAims}
-                onMouseLeave={onMouseOutAims}
-                // bg={"red"}
-              >
-                {/* Toolbar */}
-                {isEditingAims === false ? null : <RevisedRichTextToolbar />}
-
-                <Box pos={"relative"}>
-                  <Text
-                    fontWeight={"bold"}
-                    fontSize={"lg"}
-                    px={8}
-                    ml={"2px"}
-                    mt={4}
-                    // userSelect={"none"}
-                  >
-                    Aims
-                  </Text>
-
-                  {isEditingAims === true ? (
-                    <Box pos={"absolute"} right={10} top={0}>
-                      <Flex flexDir={"row"}>
-                        <Button
-                          bg={colorMode === "light" ? `green.500` : `green.600`}
-                          color={
-                            colorMode === "light"
-                              ? "whiteAlpha.900"
-                              : "whiteAlpha.800"
-                          }
-                          _hover={
-                            colorMode === "light"
-                              ? {
-                                  bg: `green.600`,
-                                  color: `white`,
-                                }
-                              : {
-                                  bg: `green.500`,
-                                  color: `white`,
-                                }
-                          }
-                          minW={"32px"}
-                          minH={"32px"}
-                          maxW={"32px"}
-                          maxH={"32px"}
-                          rounded={"full"}
-                          data-tip="Click to Save"
-                          onClick={() =>
-                            onSave({
-                              mainDocumentId: fullPRData?.document?.pk,
-                              section: "aims",
-                              htmlData: aimsDisplayData,
-                            })
-                          }
-                        >
-                          <Icon as={FaSave} />
-                        </Button>
-
-                        <Button
-                          ml={2}
-                          bg={colorMode === "light" ? `gray.500` : `gray.600`}
-                          color={
-                            colorMode === "light"
-                              ? "whiteAlpha.900"
-                              : "whiteAlpha.800"
-                          }
-                          _hover={
-                            colorMode === "light"
-                              ? {
-                                  bg: `gray.600`,
-                                  color: `white`,
-                                }
-                              : {
-                                  bg: `gray.500`,
-                                  color: `white`,
-                                }
-                          }
-                          minW={"32px"}
-                          minH={"32px"}
-                          maxW={"32px"}
-                          maxH={"32px"}
-                          rounded={"full"}
-                          data-tip="Click to Save"
-                          onClick={() => setIsEditingAims(false)}
-                        >
-                          <Icon as={AiFillEyeInvisible} />
-                        </Button>
-                      </Flex>
-                    </Box>
-                  ) : isHoveredAims ? (
-                    <Box pos={"absolute"} right={10} top={0}>
-                      <Button
-                        ml={2}
-                        bg={colorMode === "light" ? `gray.500` : `gray.600`}
-                        color={
-                          colorMode === "light"
-                            ? "whiteAlpha.900"
-                            : "whiteAlpha.800"
-                        }
-                        _hover={
-                          colorMode === "light"
-                            ? {
-                                bg: `gray.600`,
-                                color: `white`,
-                              }
-                            : {
-                                bg: `gray.500`,
-                                color: `white`,
-                              }
-                        }
-                        minW={"32px"}
-                        minH={"32px"}
-                        maxW={"32px"}
-                        maxH={"32px"}
-                        rounded={"full"}
-                        data-tip="Click to Save"
-                        onClick={() => setIsEditingAims(true)}
-                      >
-                        <Icon as={AiFillEdit} />
-                      </Button>
-                    </Box>
-                  ) : null}
-                </Box>
-
-                <Box mt={"-15px"} className="editor-scroller">
-                  <Box
-                    //   className="editor"
-                    //   ref={onRef}
-                    style={{
-                      // background: "red",
-                      marginLeft: `${dragBtnMargin}px`,
-                    }}
-                  >
-                    <ContentEditable
-                      style={{
-                        minHeight: "50px",
-                        width: "100%",
-                        height: "auto",
-                        padding: "32px",
-                        paddingBottom: "16px",
-                        //   borderRadius: "0 0 25px 25px",
-                        outline: "none",
-                        marginLeft: -8,
-                      }}
-
-                      // autoFocus
-                    />
-                  </Box>
-                </Box>
-                {/* <Box>Editor: {editorText}</Box> */}
-              </Box>
-            }
-            // placeholder={
-            //     isEditing ?
-            //         <Box
-            //             style={{
-            //                 position: "absolute",
-            //                 left: `${24 + dragBtnMargin}px`,
-            //                 top: `${75 + aboveContentHeight + toolBarHeight}px`,
-            //                 userSelect: "none",
-            //                 pointerEvents: "none",
-            //                 color: "gray",
-            //             }}
-            //         >
-            //             {`Enter text...`}
-            //         </Box>
-            //         : null
-            // }
-            ErrorBoundary={LexicalErrorBoundary}
-          />
-
-          <TabIndentationPlugin />
-          <ListMaxIndentLevelPlugin maxDepth={3} />
-          <AutoFocusPlugin />
-        </LexicalComposer>
-
-        {/* Progress */}
-        <LexicalComposer
-          key={`progress-${initialConfigProgress.editable}`}
-          initialConfig={initialConfigProgress}
-        >
-          {/* Plugins*/}
-          <TablePlugin hasCellMerge={true} hasCellBackgroundColor={false} />
-          <HistoryPlugin />
-          <ListPlugin />
-
-          <OnChangePlugin
-            onChange={(editorState, editor) => {
-              editorState.read(() => {
-                const root = $getRoot();
-
-                // setEditorText(root.__cachedText);
-                const newHtml = $generateHtmlFromNodes(editor, null);
-                // setHtmlData(newHtml);
-                setProgressReportDisplayData(newHtml);
-              });
-            }}
-          />
-          {/* {data !== undefined && data !== null && ( */}
-          <PrepopulateHTMLPlugin data={progressReportDisplayData} />
-          {/* )} */}
-          <CustomPastePlugin />
-
-          {/* Text Area */}
-          <RichTextPlugin
-            placeholder={<Text></Text>}
-            contentEditable={
-              <Box
-                mt={4}
-                onMouseOver={onMouseOverProgress}
-                onMouseLeave={onMouseOutProgress}
-                // bg={"red"}
-              >
-                {/* Toolbar */}
-                {isEditingProgress === false ? null : (
-                  <RevisedRichTextToolbar />
-                )}
-
-                <Box pos={"relative"}>
-                  <Text
-                    fontWeight={"bold"}
-                    fontSize={"lg"}
-                    px={8}
-                    ml={"2px"}
-                    mt={4}
-                    // userSelect={"none"}
-                  >
-                    Progress
-                  </Text>
-
-                  {isEditingProgress === true ? (
-                    <Box pos={"absolute"} right={10} top={0}>
-                      <Flex flexDir={"row"}>
-                        <Button
-                          bg={colorMode === "light" ? `green.500` : `green.600`}
-                          color={
-                            colorMode === "light"
-                              ? "whiteAlpha.900"
-                              : "whiteAlpha.800"
-                          }
-                          _hover={
-                            colorMode === "light"
-                              ? {
-                                  bg: `green.600`,
-                                  color: `white`,
-                                }
-                              : {
-                                  bg: `green.500`,
-                                  color: `white`,
-                                }
-                          }
-                          minW={"32px"}
-                          minH={"32px"}
-                          maxW={"32px"}
-                          maxH={"32px"}
-                          rounded={"full"}
-                          data-tip="Click to Save"
-                          onClick={() =>
-                            onSave({
-                              mainDocumentId: fullPRData?.document?.pk,
-                              section: "progress",
-                              htmlData: progressReportDisplayData,
-                            })
-                          }
-                        >
-                          <Icon as={FaSave} />
-                        </Button>
-
-                        <Button
-                          ml={2}
-                          bg={colorMode === "light" ? `gray.500` : `gray.600`}
-                          color={
-                            colorMode === "light"
-                              ? "whiteAlpha.900"
-                              : "whiteAlpha.800"
-                          }
-                          _hover={
-                            colorMode === "light"
-                              ? {
-                                  bg: `gray.600`,
-                                  color: `white`,
-                                }
-                              : {
-                                  bg: `gray.500`,
-                                  color: `white`,
-                                }
-                          }
-                          minW={"32px"}
-                          minH={"32px"}
-                          maxW={"32px"}
-                          maxH={"32px"}
-                          rounded={"full"}
-                          data-tip="Click to Save"
-                          onClick={() => setIsEditingProgress(false)}
-                        >
-                          <Icon as={AiFillEyeInvisible} />
-                        </Button>
-                      </Flex>
-                    </Box>
-                  ) : isHoveredProgress ? (
-                    <Box pos={"absolute"} right={10} top={0}>
-                      <Button
-                        ml={2}
-                        bg={colorMode === "light" ? `gray.500` : `gray.600`}
-                        color={
-                          colorMode === "light"
-                            ? "whiteAlpha.900"
-                            : "whiteAlpha.800"
-                        }
-                        _hover={
-                          colorMode === "light"
-                            ? {
-                                bg: `gray.600`,
-                                color: `white`,
-                              }
-                            : {
-                                bg: `gray.500`,
-                                color: `white`,
-                              }
-                        }
-                        minW={"32px"}
-                        minH={"32px"}
-                        maxW={"32px"}
-                        maxH={"32px"}
-                        rounded={"full"}
-                        data-tip="Click to Save"
-                        onClick={() => setIsEditingProgress(true)}
-                      >
-                        <Icon as={AiFillEdit} />
-                      </Button>
-                    </Box>
-                  ) : null}
-                </Box>
-
-                <Box mt={"-15px"} className="editor-scroller">
-                  <Box
-                    //   className="editor"
-                    //   ref={onRef}
-                    style={{
-                      // background: "red",
-                      marginLeft: `${dragBtnMargin}px`,
-                    }}
-                  >
-                    <ContentEditable
-                      style={{
-                        minHeight: "50px",
-                        width: "100%",
-                        height: "auto",
-                        padding: "32px",
-                        paddingBottom: "16px",
-                        //   borderRadius: "0 0 25px 25px",
-                        outline: "none",
-                        marginLeft: -8,
-                      }}
-
-                      // autoFocus
-                    />
-                  </Box>
-                </Box>
-                {/* <Box>Editor: {editorText}</Box> */}
-              </Box>
-            }
-            // placeholder={
-            //     isEditing ?
-            //         <Box
-            //             style={{
-            //                 position: "absolute",
-            //                 left: `${24 + dragBtnMargin}px`,
-            //                 top: `${75 + aboveContentHeight + toolBarHeight}px`,
-            //                 userSelect: "none",
-            //                 pointerEvents: "none",
-            //                 color: "gray",
-            //             }}
-            //         >
-            //             {`Enter text...`}
-            //         </Box>
-            //         : null
-            // }
-            ErrorBoundary={LexicalErrorBoundary}
-          />
-
-          <TabIndentationPlugin />
-          <ListMaxIndentLevelPlugin maxDepth={3} />
-          <AutoFocusPlugin />
-        </LexicalComposer>
-
-        {/* Management Implications */}
-        <LexicalComposer
-          key={`implications-${initialConfigImplications.editable}`}
-          initialConfig={initialConfigImplications}
-        >
-          {/* Plugins*/}
-          <TablePlugin hasCellMerge={true} hasCellBackgroundColor={false} />
-          <HistoryPlugin />
-          <ListPlugin />
-
-          <OnChangePlugin
-            onChange={(editorState, editor) => {
-              editorState.read(() => {
-                const root = $getRoot();
-
-                // setEditorText(root.__cachedText);
-                const newHtml = $generateHtmlFromNodes(editor, null);
-                // setHtmlData(newHtml);
-                setManagementImplicationsDisplayData(newHtml);
-              });
-            }}
-          />
-          {/* {data !== undefined && data !== null && ( */}
-          <PrepopulateHTMLPlugin data={managementImplicationsDisplayData} />
-          {/* )} */}
-          <CustomPastePlugin />
-
-          {/* Text Area */}
-          <RichTextPlugin
-            placeholder={<Text></Text>}
-            contentEditable={
-              <Box
-                mt={4}
-                onMouseOver={onMouseOverImplications}
-                onMouseLeave={onMouseOutImplications}
-                // bg={"red"}
-              >
-                {/* Toolbar */}
-                {isEditingImplications === false ? null : (
-                  <RevisedRichTextToolbar />
-                )}
-
-                <Box pos={"relative"}>
-                  <Text
-                    fontWeight={"bold"}
-                    fontSize={"lg"}
-                    px={8}
-                    ml={"2px"}
-                    mt={4}
-                    // userSelect={"none"}
-                  >
-                    Management Implications
-                  </Text>
-
-                  {isEditingImplications === true ? (
-                    <Box pos={"absolute"} right={10} top={0}>
-                      <Flex flexDir={"row"}>
-                        <Button
-                          bg={colorMode === "light" ? `green.500` : `green.600`}
-                          color={
-                            colorMode === "light"
-                              ? "whiteAlpha.900"
-                              : "whiteAlpha.800"
-                          }
-                          _hover={
-                            colorMode === "light"
-                              ? {
-                                  bg: `green.600`,
-                                  color: `white`,
-                                }
-                              : {
-                                  bg: `green.500`,
-                                  color: `white`,
-                                }
-                          }
-                          minW={"32px"}
-                          minH={"32px"}
-                          maxW={"32px"}
-                          maxH={"32px"}
-                          rounded={"full"}
-                          data-tip="Click to Save"
-                          onClick={() =>
-                            onSave({
-                              mainDocumentId: fullPRData?.document?.pk,
-                              section: "implications",
-                              htmlData: managementImplicationsDisplayData,
-                            })
-                          }
-                        >
-                          <Icon as={FaSave} />
-                        </Button>
-
-                        <Button
-                          ml={2}
-                          bg={colorMode === "light" ? `gray.500` : `gray.600`}
-                          color={
-                            colorMode === "light"
-                              ? "whiteAlpha.900"
-                              : "whiteAlpha.800"
-                          }
-                          _hover={
-                            colorMode === "light"
-                              ? {
-                                  bg: `gray.600`,
-                                  color: `white`,
-                                }
-                              : {
-                                  bg: `gray.500`,
-                                  color: `white`,
-                                }
-                          }
-                          minW={"32px"}
-                          minH={"32px"}
-                          maxW={"32px"}
-                          maxH={"32px"}
-                          rounded={"full"}
-                          data-tip="Click to Save"
-                          onClick={() => setIsEditingImplications(false)}
-                        >
-                          <Icon as={AiFillEyeInvisible} />
-                        </Button>
-                      </Flex>
-                    </Box>
-                  ) : isHoveredImplications ? (
-                    <Box pos={"absolute"} right={10} top={0}>
-                      <Button
-                        ml={2}
-                        bg={colorMode === "light" ? `gray.500` : `gray.600`}
-                        color={
-                          colorMode === "light"
-                            ? "whiteAlpha.900"
-                            : "whiteAlpha.800"
-                        }
-                        _hover={
-                          colorMode === "light"
-                            ? {
-                                bg: `gray.600`,
-                                color: `white`,
-                              }
-                            : {
-                                bg: `gray.500`,
-                                color: `white`,
-                              }
-                        }
-                        minW={"32px"}
-                        minH={"32px"}
-                        maxW={"32px"}
-                        maxH={"32px"}
-                        rounded={"full"}
-                        data-tip="Click to Save"
-                        onClick={() => setIsEditingImplications(true)}
-                      >
-                        <Icon as={AiFillEdit} />
-                      </Button>
-                    </Box>
-                  ) : null}
-                </Box>
-
-                <Box mt={"-15px"} className="editor-scroller">
-                  <Box
-                    //   className="editor"
-                    //   ref={onRef}
-                    style={{
-                      // background: "red",
-                      marginLeft: `${dragBtnMargin}px`,
-                    }}
-                  >
-                    <ContentEditable
-                      style={{
-                        minHeight: "50px",
-                        width: "100%",
-                        height: "auto",
-                        padding: "32px",
-                        paddingBottom: "16px",
-                        //   borderRadius: "0 0 25px 25px",
-                        outline: "none",
-                        marginLeft: -8,
-                      }}
-
-                      // autoFocus
-                    />
-                  </Box>
-                </Box>
-                {/* <Box>Editor: {editorText}</Box> */}
-              </Box>
-            }
-            // placeholder={
-            //     isEditing ?
-            //         <Box
-            //             style={{
-            //                 position: "absolute",
-            //                 left: `${24 + dragBtnMargin}px`,
-            //                 top: `${75 + aboveContentHeight + toolBarHeight}px`,
-            //                 userSelect: "none",
-            //                 pointerEvents: "none",
-            //                 color: "gray",
-            //             }}
-            //         >
-            //             {`Enter text...`}
-            //         </Box>
-            //         : null
-            // }
-            ErrorBoundary={LexicalErrorBoundary}
-          />
-
-          <TabIndentationPlugin />
-          <ListMaxIndentLevelPlugin maxDepth={3} />
-          <AutoFocusPlugin />
-        </LexicalComposer>
-
-        {/* Future Directions */}
-        <LexicalComposer
-          key={`future-${initialConfigFuture.editable}`}
-          initialConfig={initialConfigFuture}
-        >
-          {/* Plugins*/}
-          <TablePlugin hasCellMerge={true} hasCellBackgroundColor={false} />
-          <HistoryPlugin />
-          <ListPlugin />
-
-          <OnChangePlugin
-            onChange={(editorState, editor) => {
-              editorState.read(() => {
-                const root = $getRoot();
-
-                // setEditorText(root.__cachedText);
-                const newHtml = $generateHtmlFromNodes(editor, null);
-                // setHtmlData(newHtml);
-                setFutureDirectionsDisplayData(newHtml);
-              });
-            }}
-          />
-          {/* {data !== undefined && data !== null && ( */}
-          <PrepopulateHTMLPlugin data={futureDirectionsDisplayData} />
-          {/* )} */}
-          <CustomPastePlugin />
-
-          {/* Text Area */}
-          <RichTextPlugin
-            placeholder={<Text></Text>}
-            contentEditable={
-              <Box
-                mt={4}
-                onMouseOver={onMouseOverFuture}
-                onMouseLeave={onMouseOutFuture}
-                // bg={"red"}
-              >
-                {/* Toolbar */}
-                {isEditingFuture === false ? null : <RevisedRichTextToolbar />}
-
-                <Box pos={"relative"}>
-                  <Text
-                    fontWeight={"bold"}
-                    fontSize={"lg"}
-                    px={8}
-                    ml={"2px"}
-                    mt={4}
-                    // userSelect={"none"}
-                  >
-                    Future Directions
-                  </Text>
-
-                  {isEditingFuture === true ? (
-                    <Box pos={"absolute"} right={10} top={0}>
-                      <Flex flexDir={"row"}>
-                        <Button
-                          bg={colorMode === "light" ? `green.500` : `green.600`}
-                          color={
-                            colorMode === "light"
-                              ? "whiteAlpha.900"
-                              : "whiteAlpha.800"
-                          }
-                          _hover={
-                            colorMode === "light"
-                              ? {
-                                  bg: `green.600`,
-                                  color: `white`,
-                                }
-                              : {
-                                  bg: `green.500`,
-                                  color: `white`,
-                                }
-                          }
-                          minW={"32px"}
-                          minH={"32px"}
-                          maxW={"32px"}
-                          maxH={"32px"}
-                          rounded={"full"}
-                          data-tip="Click to Save"
-                          onClick={() =>
-                            onSave({
-                              mainDocumentId: fullPRData?.document?.pk,
-                              section: "future",
-                              htmlData: futureDirectionsDisplayData,
-                            })
-                          }
-                        >
-                          <Icon as={FaSave} />
-                        </Button>
-
-                        <Button
-                          ml={2}
-                          bg={colorMode === "light" ? `gray.500` : `gray.600`}
-                          color={
-                            colorMode === "light"
-                              ? "whiteAlpha.900"
-                              : "whiteAlpha.800"
-                          }
-                          _hover={
-                            colorMode === "light"
-                              ? {
-                                  bg: `gray.600`,
-                                  color: `white`,
-                                }
-                              : {
-                                  bg: `gray.500`,
-                                  color: `white`,
-                                }
-                          }
-                          minW={"32px"}
-                          minH={"32px"}
-                          maxW={"32px"}
-                          maxH={"32px"}
-                          rounded={"full"}
-                          data-tip="Click to Save"
-                          onClick={() => setIsEditingFuture(false)}
-                        >
-                          <Icon as={AiFillEyeInvisible} />
-                        </Button>
-                      </Flex>
-                    </Box>
-                  ) : isHoveredFuture ? (
-                    <Box pos={"absolute"} right={10} top={0}>
-                      <Button
-                        ml={2}
-                        bg={colorMode === "light" ? `gray.500` : `gray.600`}
-                        color={
-                          colorMode === "light"
-                            ? "whiteAlpha.900"
-                            : "whiteAlpha.800"
-                        }
-                        _hover={
-                          colorMode === "light"
-                            ? {
-                                bg: `gray.600`,
-                                color: `white`,
-                              }
-                            : {
-                                bg: `gray.500`,
-                                color: `white`,
-                              }
-                        }
-                        minW={"32px"}
-                        minH={"32px"}
-                        maxW={"32px"}
-                        maxH={"32px"}
-                        rounded={"full"}
-                        data-tip="Click to Save"
-                        onClick={() => setIsEditingFuture(true)}
-                      >
-                        <Icon as={AiFillEdit} />
-                      </Button>
-                    </Box>
-                  ) : null}
-                </Box>
-
-                <Box mt={"-15px"} className="editor-scroller">
-                  <Box
-                    //   className="editor"
-                    //   ref={onRef}
-                    style={{
-                      // background: "red",
-                      marginLeft: `${dragBtnMargin}px`,
-                    }}
-                  >
-                    <ContentEditable
-                      style={{
-                        minHeight: "50px",
-                        width: "100%",
-                        height: "auto",
-                        padding: "32px",
-                        paddingBottom: "16px",
-                        //   borderRadius: "0 0 25px 25px",
-                        outline: "none",
-                        marginLeft: -8,
-                      }}
-
-                      // autoFocus
-                    />
-                  </Box>
-                </Box>
-                {/* <Box>Editor: {editorText}</Box> */}
-              </Box>
-            }
-            // placeholder={
-            //     isEditing ?
-            //         <Box
-            //             style={{
-            //                 position: "absolute",
-            //                 left: `${24 + dragBtnMargin}px`,
-            //                 top: `${75 + aboveContentHeight + toolBarHeight}px`,
-            //                 userSelect: "none",
-            //                 pointerEvents: "none",
-            //                 color: "gray",
-            //             }}
-            //         >
-            //             {`Enter text...`}
-            //         </Box>
-            //         : null
-            // }
-            ErrorBoundary={LexicalErrorBoundary}
-          />
-
-          <TabIndentationPlugin />
-          <ListMaxIndentLevelPlugin maxDepth={3} />
-          <AutoFocusPlugin />
-        </LexicalComposer>
-      </Box>
-    </>
-  );
+	// const navigate = useNavigate();
+	const { colorMode } = useColorMode();
+
+	// const editorInstance = useLexicalComposerContext();
+
+	// useEffect(() => {
+
+	//     if (editorInstance) {
+	//       // Perform operations on the Lexical editor instance
+	//       const root = editorInstance.$getRoot();
+	//       setEditorText(root.__cachedText);
+	//     }
+	//   }, [editorRef, setEditorText]);
+
+	const dragBtnMargin = 10;
+	const toolBarHeight = 45;
+	const [aboveHeightSet, setAboveHeightSet] = useState<boolean>(false);
+	const [aboveContentHeight, setAboveContentHeight] = useState<number>();
+
+	// const [htmlData, setHtmlData] = useState(fullSRData?.progress_report);
+
+	// Mouse Over and Out each editor
+	const [isHoveredContext, setIsHoveredContext] = useState(false);
+	const [isHoveredAims, setIsHoveredAims] = useState(false);
+	const [isHoveredProgress, setIsHoveredProgress] = useState(false);
+	const [isHoveredImplications, setIsHoveredImplications] = useState(false);
+	const [isHoveredFuture, setIsHoveredFuture] = useState(false);
+
+	const onMouseOverContext = () => {
+		if (!isHoveredContext) {
+			setIsHoveredContext(true);
+		}
+	};
+
+	const onMouseOutContext = () => {
+		if (isHoveredContext) {
+			setIsHoveredContext(false);
+		}
+	};
+
+	const onMouseOverAims = () => {
+		if (!isHoveredAims) {
+			setIsHoveredAims(true);
+		}
+	};
+
+	const onMouseOutAims = () => {
+		if (isHoveredAims) {
+			setIsHoveredAims(false);
+		}
+	};
+	const onMouseOverProgress = () => {
+		if (!isHoveredProgress) {
+			setIsHoveredProgress(true);
+		}
+	};
+
+	const onMouseOutProgress = () => {
+		if (isHoveredProgress) {
+			setIsHoveredProgress(false);
+		}
+	};
+	const onMouseOverImplications = () => {
+		if (!isHoveredImplications) {
+			setIsHoveredImplications(true);
+		}
+	};
+
+	const onMouseOutImplications = () => {
+		if (isHoveredImplications) {
+			setIsHoveredImplications(false);
+		}
+	};
+	const onMouseOverFuture = () => {
+		if (!isHoveredFuture) {
+			setIsHoveredFuture(true);
+		}
+	};
+
+	const onMouseOutFuture = () => {
+		if (isHoveredFuture) {
+			setIsHoveredFuture(false);
+		}
+	};
+
+	// useEffect(() => {
+	//     setAboveHeightSet(false);
+	//     const calculateAboveContentHeight = () => {
+	//         const aboveContentElement = document.getElementById(`topContent_${fullPRData?.project?.pk}`);
+
+	//         if (aboveContentElement) {
+	//             const rect = aboveContentElement.getBoundingClientRect();
+	//             const contentAboveHeight = rect.bottom - rect.top;
+	//             setAboveContentHeight(contentAboveHeight);
+	//         }
+	//     };
+
+	//     // Call the function initially
+	//     calculateAboveContentHeight();
+
+	//     // Attach resize event listener to recalculate height when the window is resized
+	//     window.addEventListener('resize', calculateAboveContentHeight);
+	//     setAboveHeightSet(true);
+
+	//     // Cleanup event listener on component unmount
+	//     return () => {
+	//         window.removeEventListener('resize', calculateAboveContentHeight);
+	//     };
+	// }, [displayData, isEditing, fullPRData?.project?.pk, initialConfig]);
+
+	const queryClient = useQueryClient();
+	const { register, handleSubmit, reset } =
+		useForm<ISaveProgressReportSection>();
+	const toast = useToast();
+	const toastIdRef = useRef<ToastId>();
+	const addToast = (data) => {
+		toastIdRef.current = toast(data);
+	};
+
+	const saveMutation = useMutation({
+		mutationFn: updateProgressReportSection,
+		onMutate: () => {
+			addToast({
+				status: "loading",
+				title: "Updating Progress Report",
+				position: "top-right",
+			});
+		},
+		onSuccess: () => {
+			if (toastIdRef.current) {
+				toast.update(toastIdRef.current, {
+					title: "Success",
+					description: `Progress Report Updated`,
+					status: "success",
+					position: "top-right",
+					duration: 3000,
+					isClosable: true,
+				});
+			}
+			// reset();
+
+			// setTimeout(() => {
+			//   queryClient.invalidateQueries(["mytasks"]);
+			// }, 350);
+		},
+		onError: (error) => {
+			if (toastIdRef.current) {
+				toast.update(toastIdRef.current, {
+					title: "Could Not Update Progress Report",
+					description: `${error}`,
+					status: "error",
+					position: "top-right",
+					duration: 3000,
+					isClosable: true,
+				});
+			}
+		},
+	});
+
+	const onSave = (formData: ISaveProgressReportSection) => {
+		const section = formData.section;
+
+		saveMutation.mutate(formData);
+		if (section === "context") {
+			setIsEditingContext(false);
+		} else if (section === "aims") {
+			setIsEditingAims(false);
+		} else if (section === "progress") {
+			setIsEditingProgress(false);
+		} else if (section === "implications") {
+			setIsEditingImplications(false);
+		} else if (section === "future") {
+			setIsEditingFuture(false);
+		}
+	};
+
+	const [initialConfigFuture, setInitialConfigFuture] =
+		useState<InitialConfigType>(uneditableInitialConfig);
+	const [initialConfigImplications, setInitialConfigImplications] =
+		useState<InitialConfigType>(uneditableInitialConfig);
+	const [initialConfigProgress, setInitialConfigProgress] =
+		useState<InitialConfigType>(uneditableInitialConfig);
+	const [initialConfigAims, setInitialConfigAims] =
+		useState<InitialConfigType>(uneditableInitialConfig);
+	const [initialConfigContext, setInitialConfigContext] =
+		useState<InitialConfigType>(uneditableInitialConfig);
+
+	useEffect(() => {
+		if (isEditingContext) {
+			if (initialConfigContext.editable === false) {
+				setInitialConfigContext(editableInitialConfig);
+			}
+		} else {
+			if (initialConfigContext.editable === true) {
+				setInitialConfigContext(uneditableInitialConfig);
+			}
+		}
+	}, [
+		initialConfigContext,
+		isEditingContext,
+		editableInitialConfig,
+		uneditableInitialConfig,
+	]);
+
+	useEffect(() => {
+		if (isEditingAims) {
+			if (initialConfigAims.editable === false) {
+				setInitialConfigAims(editableInitialConfig);
+			}
+		} else {
+			if (initialConfigAims.editable === true) {
+				setInitialConfigAims(uneditableInitialConfig);
+			}
+		}
+	}, [
+		initialConfigAims,
+		isEditingAims,
+		editableInitialConfig,
+		uneditableInitialConfig,
+	]);
+
+	useEffect(() => {
+		if (isEditingProgress) {
+			if (initialConfigProgress.editable === false) {
+				setInitialConfigProgress(editableInitialConfig);
+			}
+		} else {
+			if (initialConfigProgress.editable === true) {
+				setInitialConfigProgress(uneditableInitialConfig);
+			}
+		}
+	}, [
+		initialConfigProgress,
+		isEditingProgress,
+		editableInitialConfig,
+		uneditableInitialConfig,
+	]);
+
+	useEffect(() => {
+		if (initialConfigFuture.editable === false) {
+			if (isEditingFuture) {
+				setInitialConfigFuture(editableInitialConfig);
+			}
+		} else if (initialConfigFuture.editable === true) {
+			if (!isEditingFuture) {
+				setInitialConfigFuture(uneditableInitialConfig);
+			}
+		}
+	}, [
+		initialConfigFuture,
+		isEditingFuture,
+		editableInitialConfig,
+		uneditableInitialConfig,
+	]);
+
+	useEffect(() => {
+		if (initialConfigImplications.editable === false) {
+			if (isEditingImplications) {
+				setInitialConfigImplications(editableInitialConfig);
+			}
+		} else if (initialConfigImplications.editable === true) {
+			if (!isEditingImplications) {
+				setInitialConfigImplications(uneditableInitialConfig);
+			}
+		}
+	}, [
+		initialConfigImplications,
+		isEditingImplications,
+		editableInitialConfig,
+		uneditableInitialConfig,
+	]);
+
+	const {
+		isOpen: isApproveProgressReportOpen,
+		onOpen: onOpenApproveProgressReport,
+		onClose: onCloseApproveProgressReport,
+	} = useDisclosure();
+	const [reportHovered, setReportHovered] = useState(false);
+	const [isActive, setIsActive] = useState(
+		fullPRData?.document?.project?.status === "active"
+	);
+	useEffect(() => {
+		setIsActive(fullPRData?.document?.project?.status === "active");
+	}, [fullPRData]);
+
+	const noImage = useNoImage();
+
+	return (
+		<>
+			{/* setIsEditing */}
+			<ApproveProgressReportModal
+				isActive={isActive}
+				report={fullPRData}
+				isOpen={isApproveProgressReportOpen}
+				onClose={onCloseApproveProgressReport}
+			/>
+			<Box
+				mx={4}
+				pos={"relative"}
+				roundedBottom={20}
+				roundedTop={20}
+				mb={4}
+				boxShadow={
+					"0 8px 24px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.1)"
+				}
+				bg={colorMode === "light" ? "whiteAlpha.600" : "blackAlpha.500"}
+				onMouseOver={() => setReportHovered(true)}
+				onMouseOut={() => setReportHovered(false)}
+			>
+				{reportHovered ? (
+					<Box pos={"absolute"} right={4} top={4}>
+						<Button
+							ml={2}
+							bg={
+								isActive
+									? colorMode === "light"
+										? `orange.500`
+										: `orange.600`
+									: colorMode === "light"
+										? `green.500`
+										: `green.600`
+							}
+							color={
+								colorMode === "light"
+									? "whiteAlpha.900"
+									: "whiteAlpha.800"
+							}
+							_hover={
+								colorMode === "light"
+									? {
+											bg: isActive
+												? `orange.600`
+												: `green.600`,
+											color: `white`,
+										}
+									: {
+											bg: isActive
+												? `orange.500`
+												: `green.500`,
+											color: `white`,
+										}
+							}
+							minW={"32px"}
+							minH={"32px"}
+							maxW={"32px"}
+							maxH={"32px"}
+							rounded={"full"}
+							data-tip="Click to edit"
+							onClick={onOpenApproveProgressReport}
+						>
+							<Icon as={isActive ? FaUndo : TiTick} />
+						</Button>
+					</Box>
+				) : null}
+
+				<Flex
+					id={`topContent_${fullPRData?.document?.project?.pk}`}
+					pt={6}
+					mx={8}
+				>
+					{!shouldAlternatePicture ? (
+						<>
+							<Box
+								rounded={"md"}
+								overflow={"hidden"}
+								w={"276px"}
+								h={"200px"}
+							>
+								<Image
+									src={
+										fullPRData?.document?.project?.image
+											?.file ?? noImage
+									}
+									w={"100%"}
+									h={"100%"}
+									objectFit={"cover"}
+								/>
+							</Box>
+							<Box ml={4} flex={1}>
+								<Box>
+									<ExtractedHTMLTitle
+										htmlContent={
+											fullPRData?.document?.project?.title
+										}
+										color={"blue.500"}
+										fontWeight={"bold"}
+										fontSize={"17px"}
+										// fontSize={"xs"}
+										noOfLines={4}
+										cursor={"pointer"}
+										onClick={() => {
+											const url = `/projects/${fullPRData?.document?.project?.pk}/progress`;
+											window.open(url, "_blank");
+											// navigate(url);
+										}}
+									/>
+								</Box>
+
+								<PRProjDetails
+									project={fullPRData?.document?.project}
+									team_members={fullPRData?.team_members}
+								/>
+							</Box>
+						</>
+					) : (
+						<>
+							<Box mr={4} flex={1}>
+								<Box>
+									<ExtractedHTMLTitle
+										htmlContent={
+											fullPRData?.document?.project?.title
+										}
+										color={"blue.500"}
+										fontWeight={"bold"}
+										fontSize={"17px"}
+										// fontSize={"xs"}
+										cursor={"pointer"}
+										onClick={() => {
+											const url = `/projects/${fullPRData?.document?.project?.pk}/progress`;
+											window.open(url, "_blank");
+											// navigate(url);
+										}}
+										noOfLines={4}
+									/>
+								</Box>
+
+								<PRProjDetails
+									project={fullPRData?.document?.project}
+									team_members={fullPRData?.team_members}
+								/>
+							</Box>
+							<Box
+								rounded={"md"}
+								overflow={"hidden"}
+								w={"276px"}
+								h={"200px"}
+							>
+								<Image
+									src={
+										fullPRData?.document?.project?.image
+											?.file ?? noImage
+									}
+									w={"100%"}
+									h={"100%"}
+									objectFit={"cover"}
+								/>
+							</Box>
+						</>
+					)}
+				</Flex>
+				{/* Context */}
+				<LexicalComposer
+					key={`context-${initialConfigContext.editable}`}
+					initialConfig={initialConfigContext}
+				>
+					{/* Plugins*/}
+					<TablePlugin
+						hasCellMerge={true}
+						hasCellBackgroundColor={false}
+					/>
+					<HistoryPlugin />
+					<ListPlugin />
+
+					<OnChangePlugin
+						onChange={(editorState, editor) => {
+							editorState.read(() => {
+								const root = $getRoot();
+
+								// setEditorText(root.__cachedText);
+								const newHtml = $generateHtmlFromNodes(
+									editor,
+									null
+								);
+								// setHtmlData(newHtml);
+								setContextDisplayData(newHtml);
+							});
+						}}
+					/>
+					{/* {data !== undefined && data !== null && ( */}
+					<PrepopulateHTMLPlugin data={contextDisplayData} />
+					{/* )} */}
+					<CustomPastePlugin />
+
+					{/* Text Area */}
+					<RichTextPlugin
+						placeholder={<Text></Text>}
+						contentEditable={
+							<Box
+								mt={4}
+								onMouseOver={onMouseOverContext}
+								onMouseLeave={onMouseOutContext}
+								// bg={"red"}
+							>
+								{/* Toolbar */}
+								{isEditingContext === false ? null : (
+									<RevisedRichTextToolbar />
+								)}
+
+								<Box pos={"relative"}>
+									<Text
+										fontWeight={"bold"}
+										fontSize={"lg"}
+										px={8}
+										ml={"2px"}
+										mt={4}
+										// userSelect={"none"}
+									>
+										Context
+									</Text>
+
+									{isEditingContext === true ? (
+										<Box
+											pos={"absolute"}
+											right={10}
+											top={0}
+										>
+											<Flex flexDir={"row"}>
+												<Button
+													bg={
+														colorMode === "light"
+															? `green.500`
+															: `green.600`
+													}
+													color={
+														colorMode === "light"
+															? "whiteAlpha.900"
+															: "whiteAlpha.800"
+													}
+													_hover={
+														colorMode === "light"
+															? {
+																	bg: `green.600`,
+																	color: `white`,
+																}
+															: {
+																	bg: `green.500`,
+																	color: `white`,
+																}
+													}
+													minW={"32px"}
+													minH={"32px"}
+													maxW={"32px"}
+													maxH={"32px"}
+													rounded={"full"}
+													data-tip="Click to Save"
+													onClick={() =>
+														onSave({
+															mainDocumentId:
+																fullPRData
+																	?.document
+																	?.pk,
+															section: "context",
+															htmlData:
+																contextDisplayData,
+														})
+													}
+												>
+													<Icon as={FaSave} />
+												</Button>
+
+												<Button
+													ml={2}
+													bg={
+														colorMode === "light"
+															? `gray.500`
+															: `gray.600`
+													}
+													color={
+														colorMode === "light"
+															? "whiteAlpha.900"
+															: "whiteAlpha.800"
+													}
+													_hover={
+														colorMode === "light"
+															? {
+																	bg: `gray.600`,
+																	color: `white`,
+																}
+															: {
+																	bg: `gray.500`,
+																	color: `white`,
+																}
+													}
+													minW={"32px"}
+													minH={"32px"}
+													maxW={"32px"}
+													maxH={"32px"}
+													rounded={"full"}
+													data-tip="Click to Save"
+													onClick={() =>
+														setIsEditingContext(
+															false
+														)
+													}
+												>
+													<Icon
+														as={AiFillEyeInvisible}
+													/>
+												</Button>
+											</Flex>
+										</Box>
+									) : isHoveredContext ? (
+										<Box
+											pos={"absolute"}
+											right={10}
+											top={0}
+										>
+											<Button
+												ml={2}
+												bg={
+													colorMode === "light"
+														? `gray.500`
+														: `gray.600`
+												}
+												color={
+													colorMode === "light"
+														? "whiteAlpha.900"
+														: "whiteAlpha.800"
+												}
+												_hover={
+													colorMode === "light"
+														? {
+																bg: `gray.600`,
+																color: `white`,
+															}
+														: {
+																bg: `gray.500`,
+																color: `white`,
+															}
+												}
+												minW={"32px"}
+												minH={"32px"}
+												maxW={"32px"}
+												maxH={"32px"}
+												rounded={"full"}
+												data-tip="Click to Save"
+												onClick={() =>
+													setIsEditingContext(true)
+												}
+											>
+												<Icon as={AiFillEdit} />
+											</Button>
+										</Box>
+									) : null}
+								</Box>
+
+								<Box mt={"-15px"} className="editor-scroller">
+									<Box
+										//   className="editor"
+										//   ref={onRef}
+										style={{
+											// background: "red",
+											marginLeft: `${dragBtnMargin}px`,
+										}}
+									>
+										<ContentEditable
+											style={{
+												minHeight: "50px",
+												width: "100%",
+												height: "auto",
+												padding: "32px",
+												paddingBottom: "16px",
+												//   borderRadius: "0 0 25px 25px",
+												outline: "none",
+												marginLeft: -8,
+											}}
+
+											// autoFocus
+										/>
+									</Box>
+								</Box>
+								{/* <Box>Editor: {editorText}</Box> */}
+							</Box>
+						}
+						// placeholder={
+						//     isEditing ?
+						//         <Box
+						//             style={{
+						//                 position: "absolute",
+						//                 left: `${24 + dragBtnMargin}px`,
+						//                 top: `${75 + aboveContentHeight + toolBarHeight}px`,
+						//                 userSelect: "none",
+						//                 pointerEvents: "none",
+						//                 color: "gray",
+						//             }}
+						//         >
+						//             {`Enter text...`}
+						//         </Box>
+						//         : null
+						// }
+						ErrorBoundary={LexicalErrorBoundary}
+					/>
+
+					<TabIndentationPlugin />
+					<ListMaxIndentLevelPlugin maxDepth={3} />
+					<AutoFocusPlugin />
+				</LexicalComposer>
+
+				{/* Aims */}
+				<LexicalComposer
+					key={`aims-${initialConfigAims.editable}`}
+					initialConfig={initialConfigAims}
+				>
+					{/* Plugins*/}
+					<TablePlugin
+						hasCellMerge={true}
+						hasCellBackgroundColor={false}
+					/>
+					<HistoryPlugin />
+					<ListPlugin />
+
+					<OnChangePlugin
+						onChange={(editorState, editor) => {
+							editorState.read(() => {
+								const root = $getRoot();
+
+								// setEditorText(root.__cachedText);
+								const newHtml = $generateHtmlFromNodes(
+									editor,
+									null
+								);
+								// setHtmlData(newHtml);
+								setAimsDisplayData(newHtml);
+							});
+						}}
+					/>
+					{/* {data !== undefined && data !== null && ( */}
+					<PrepopulateHTMLPlugin data={aimsDisplayData} />
+					{/* )} */}
+					<CustomPastePlugin />
+
+					{/* Text Area */}
+					<RichTextPlugin
+						placeholder={<Text></Text>}
+						contentEditable={
+							<Box
+								mt={4}
+								onMouseOver={onMouseOverAims}
+								onMouseLeave={onMouseOutAims}
+								// bg={"red"}
+							>
+								{/* Toolbar */}
+								{isEditingAims === false ? null : (
+									<RevisedRichTextToolbar />
+								)}
+
+								<Box pos={"relative"}>
+									<Text
+										fontWeight={"bold"}
+										fontSize={"lg"}
+										px={8}
+										ml={"2px"}
+										mt={4}
+										// userSelect={"none"}
+									>
+										Aims
+									</Text>
+
+									{isEditingAims === true ? (
+										<Box
+											pos={"absolute"}
+											right={10}
+											top={0}
+										>
+											<Flex flexDir={"row"}>
+												<Button
+													bg={
+														colorMode === "light"
+															? `green.500`
+															: `green.600`
+													}
+													color={
+														colorMode === "light"
+															? "whiteAlpha.900"
+															: "whiteAlpha.800"
+													}
+													_hover={
+														colorMode === "light"
+															? {
+																	bg: `green.600`,
+																	color: `white`,
+																}
+															: {
+																	bg: `green.500`,
+																	color: `white`,
+																}
+													}
+													minW={"32px"}
+													minH={"32px"}
+													maxW={"32px"}
+													maxH={"32px"}
+													rounded={"full"}
+													data-tip="Click to Save"
+													onClick={() =>
+														onSave({
+															mainDocumentId:
+																fullPRData
+																	?.document
+																	?.pk,
+															section: "aims",
+															htmlData:
+																aimsDisplayData,
+														})
+													}
+												>
+													<Icon as={FaSave} />
+												</Button>
+
+												<Button
+													ml={2}
+													bg={
+														colorMode === "light"
+															? `gray.500`
+															: `gray.600`
+													}
+													color={
+														colorMode === "light"
+															? "whiteAlpha.900"
+															: "whiteAlpha.800"
+													}
+													_hover={
+														colorMode === "light"
+															? {
+																	bg: `gray.600`,
+																	color: `white`,
+																}
+															: {
+																	bg: `gray.500`,
+																	color: `white`,
+																}
+													}
+													minW={"32px"}
+													minH={"32px"}
+													maxW={"32px"}
+													maxH={"32px"}
+													rounded={"full"}
+													data-tip="Click to Save"
+													onClick={() =>
+														setIsEditingAims(false)
+													}
+												>
+													<Icon
+														as={AiFillEyeInvisible}
+													/>
+												</Button>
+											</Flex>
+										</Box>
+									) : isHoveredAims ? (
+										<Box
+											pos={"absolute"}
+											right={10}
+											top={0}
+										>
+											<Button
+												ml={2}
+												bg={
+													colorMode === "light"
+														? `gray.500`
+														: `gray.600`
+												}
+												color={
+													colorMode === "light"
+														? "whiteAlpha.900"
+														: "whiteAlpha.800"
+												}
+												_hover={
+													colorMode === "light"
+														? {
+																bg: `gray.600`,
+																color: `white`,
+															}
+														: {
+																bg: `gray.500`,
+																color: `white`,
+															}
+												}
+												minW={"32px"}
+												minH={"32px"}
+												maxW={"32px"}
+												maxH={"32px"}
+												rounded={"full"}
+												data-tip="Click to Save"
+												onClick={() =>
+													setIsEditingAims(true)
+												}
+											>
+												<Icon as={AiFillEdit} />
+											</Button>
+										</Box>
+									) : null}
+								</Box>
+
+								<Box mt={"-15px"} className="editor-scroller">
+									<Box
+										//   className="editor"
+										//   ref={onRef}
+										style={{
+											// background: "red",
+											marginLeft: `${dragBtnMargin}px`,
+										}}
+									>
+										<ContentEditable
+											style={{
+												minHeight: "50px",
+												width: "100%",
+												height: "auto",
+												padding: "32px",
+												paddingBottom: "16px",
+												//   borderRadius: "0 0 25px 25px",
+												outline: "none",
+												marginLeft: -8,
+											}}
+
+											// autoFocus
+										/>
+									</Box>
+								</Box>
+								{/* <Box>Editor: {editorText}</Box> */}
+							</Box>
+						}
+						// placeholder={
+						//     isEditing ?
+						//         <Box
+						//             style={{
+						//                 position: "absolute",
+						//                 left: `${24 + dragBtnMargin}px`,
+						//                 top: `${75 + aboveContentHeight + toolBarHeight}px`,
+						//                 userSelect: "none",
+						//                 pointerEvents: "none",
+						//                 color: "gray",
+						//             }}
+						//         >
+						//             {`Enter text...`}
+						//         </Box>
+						//         : null
+						// }
+						ErrorBoundary={LexicalErrorBoundary}
+					/>
+
+					<TabIndentationPlugin />
+					<ListMaxIndentLevelPlugin maxDepth={3} />
+					<AutoFocusPlugin />
+				</LexicalComposer>
+
+				{/* Progress */}
+				<LexicalComposer
+					key={`progress-${initialConfigProgress.editable}`}
+					initialConfig={initialConfigProgress}
+				>
+					{/* Plugins*/}
+					<TablePlugin
+						hasCellMerge={true}
+						hasCellBackgroundColor={false}
+					/>
+					<HistoryPlugin />
+					<ListPlugin />
+
+					<OnChangePlugin
+						onChange={(editorState, editor) => {
+							editorState.read(() => {
+								const root = $getRoot();
+
+								// setEditorText(root.__cachedText);
+								const newHtml = $generateHtmlFromNodes(
+									editor,
+									null
+								);
+								// setHtmlData(newHtml);
+								setProgressReportDisplayData(newHtml);
+							});
+						}}
+					/>
+					{/* {data !== undefined && data !== null && ( */}
+					<PrepopulateHTMLPlugin data={progressReportDisplayData} />
+					{/* )} */}
+					<CustomPastePlugin />
+
+					{/* Text Area */}
+					<RichTextPlugin
+						placeholder={<Text></Text>}
+						contentEditable={
+							<Box
+								mt={4}
+								onMouseOver={onMouseOverProgress}
+								onMouseLeave={onMouseOutProgress}
+								// bg={"red"}
+							>
+								{/* Toolbar */}
+								{isEditingProgress === false ? null : (
+									<RevisedRichTextToolbar />
+								)}
+
+								<Box pos={"relative"}>
+									<Text
+										fontWeight={"bold"}
+										fontSize={"lg"}
+										px={8}
+										ml={"2px"}
+										mt={4}
+										// userSelect={"none"}
+									>
+										Progress
+									</Text>
+
+									{isEditingProgress === true ? (
+										<Box
+											pos={"absolute"}
+											right={10}
+											top={0}
+										>
+											<Flex flexDir={"row"}>
+												<Button
+													bg={
+														colorMode === "light"
+															? `green.500`
+															: `green.600`
+													}
+													color={
+														colorMode === "light"
+															? "whiteAlpha.900"
+															: "whiteAlpha.800"
+													}
+													_hover={
+														colorMode === "light"
+															? {
+																	bg: `green.600`,
+																	color: `white`,
+																}
+															: {
+																	bg: `green.500`,
+																	color: `white`,
+																}
+													}
+													minW={"32px"}
+													minH={"32px"}
+													maxW={"32px"}
+													maxH={"32px"}
+													rounded={"full"}
+													data-tip="Click to Save"
+													onClick={() =>
+														onSave({
+															mainDocumentId:
+																fullPRData
+																	?.document
+																	?.pk,
+															section: "progress",
+															htmlData:
+																progressReportDisplayData,
+														})
+													}
+												>
+													<Icon as={FaSave} />
+												</Button>
+
+												<Button
+													ml={2}
+													bg={
+														colorMode === "light"
+															? `gray.500`
+															: `gray.600`
+													}
+													color={
+														colorMode === "light"
+															? "whiteAlpha.900"
+															: "whiteAlpha.800"
+													}
+													_hover={
+														colorMode === "light"
+															? {
+																	bg: `gray.600`,
+																	color: `white`,
+																}
+															: {
+																	bg: `gray.500`,
+																	color: `white`,
+																}
+													}
+													minW={"32px"}
+													minH={"32px"}
+													maxW={"32px"}
+													maxH={"32px"}
+													rounded={"full"}
+													data-tip="Click to Save"
+													onClick={() =>
+														setIsEditingProgress(
+															false
+														)
+													}
+												>
+													<Icon
+														as={AiFillEyeInvisible}
+													/>
+												</Button>
+											</Flex>
+										</Box>
+									) : isHoveredProgress ? (
+										<Box
+											pos={"absolute"}
+											right={10}
+											top={0}
+										>
+											<Button
+												ml={2}
+												bg={
+													colorMode === "light"
+														? `gray.500`
+														: `gray.600`
+												}
+												color={
+													colorMode === "light"
+														? "whiteAlpha.900"
+														: "whiteAlpha.800"
+												}
+												_hover={
+													colorMode === "light"
+														? {
+																bg: `gray.600`,
+																color: `white`,
+															}
+														: {
+																bg: `gray.500`,
+																color: `white`,
+															}
+												}
+												minW={"32px"}
+												minH={"32px"}
+												maxW={"32px"}
+												maxH={"32px"}
+												rounded={"full"}
+												data-tip="Click to Save"
+												onClick={() =>
+													setIsEditingProgress(true)
+												}
+											>
+												<Icon as={AiFillEdit} />
+											</Button>
+										</Box>
+									) : null}
+								</Box>
+
+								<Box mt={"-15px"} className="editor-scroller">
+									<Box
+										//   className="editor"
+										//   ref={onRef}
+										style={{
+											// background: "red",
+											marginLeft: `${dragBtnMargin}px`,
+										}}
+									>
+										<ContentEditable
+											style={{
+												minHeight: "50px",
+												width: "100%",
+												height: "auto",
+												padding: "32px",
+												paddingBottom: "16px",
+												//   borderRadius: "0 0 25px 25px",
+												outline: "none",
+												marginLeft: -8,
+											}}
+
+											// autoFocus
+										/>
+									</Box>
+								</Box>
+								{/* <Box>Editor: {editorText}</Box> */}
+							</Box>
+						}
+						// placeholder={
+						//     isEditing ?
+						//         <Box
+						//             style={{
+						//                 position: "absolute",
+						//                 left: `${24 + dragBtnMargin}px`,
+						//                 top: `${75 + aboveContentHeight + toolBarHeight}px`,
+						//                 userSelect: "none",
+						//                 pointerEvents: "none",
+						//                 color: "gray",
+						//             }}
+						//         >
+						//             {`Enter text...`}
+						//         </Box>
+						//         : null
+						// }
+						ErrorBoundary={LexicalErrorBoundary}
+					/>
+
+					<TabIndentationPlugin />
+					<ListMaxIndentLevelPlugin maxDepth={3} />
+					<AutoFocusPlugin />
+				</LexicalComposer>
+
+				{/* Management Implications */}
+				<LexicalComposer
+					key={`implications-${initialConfigImplications.editable}`}
+					initialConfig={initialConfigImplications}
+				>
+					{/* Plugins*/}
+					<TablePlugin
+						hasCellMerge={true}
+						hasCellBackgroundColor={false}
+					/>
+					<HistoryPlugin />
+					<ListPlugin />
+
+					<OnChangePlugin
+						onChange={(editorState, editor) => {
+							editorState.read(() => {
+								const root = $getRoot();
+
+								// setEditorText(root.__cachedText);
+								const newHtml = $generateHtmlFromNodes(
+									editor,
+									null
+								);
+								// setHtmlData(newHtml);
+								setManagementImplicationsDisplayData(newHtml);
+							});
+						}}
+					/>
+					{/* {data !== undefined && data !== null && ( */}
+					<PrepopulateHTMLPlugin
+						data={managementImplicationsDisplayData}
+					/>
+					{/* )} */}
+					<CustomPastePlugin />
+
+					{/* Text Area */}
+					<RichTextPlugin
+						placeholder={<Text></Text>}
+						contentEditable={
+							<Box
+								mt={4}
+								onMouseOver={onMouseOverImplications}
+								onMouseLeave={onMouseOutImplications}
+								// bg={"red"}
+							>
+								{/* Toolbar */}
+								{isEditingImplications === false ? null : (
+									<RevisedRichTextToolbar />
+								)}
+
+								<Box pos={"relative"}>
+									<Text
+										fontWeight={"bold"}
+										fontSize={"lg"}
+										px={8}
+										ml={"2px"}
+										mt={4}
+										// userSelect={"none"}
+									>
+										Management Implications
+									</Text>
+
+									{isEditingImplications === true ? (
+										<Box
+											pos={"absolute"}
+											right={10}
+											top={0}
+										>
+											<Flex flexDir={"row"}>
+												<Button
+													bg={
+														colorMode === "light"
+															? `green.500`
+															: `green.600`
+													}
+													color={
+														colorMode === "light"
+															? "whiteAlpha.900"
+															: "whiteAlpha.800"
+													}
+													_hover={
+														colorMode === "light"
+															? {
+																	bg: `green.600`,
+																	color: `white`,
+																}
+															: {
+																	bg: `green.500`,
+																	color: `white`,
+																}
+													}
+													minW={"32px"}
+													minH={"32px"}
+													maxW={"32px"}
+													maxH={"32px"}
+													rounded={"full"}
+													data-tip="Click to Save"
+													onClick={() =>
+														onSave({
+															mainDocumentId:
+																fullPRData
+																	?.document
+																	?.pk,
+															section:
+																"implications",
+															htmlData:
+																managementImplicationsDisplayData,
+														})
+													}
+												>
+													<Icon as={FaSave} />
+												</Button>
+
+												<Button
+													ml={2}
+													bg={
+														colorMode === "light"
+															? `gray.500`
+															: `gray.600`
+													}
+													color={
+														colorMode === "light"
+															? "whiteAlpha.900"
+															: "whiteAlpha.800"
+													}
+													_hover={
+														colorMode === "light"
+															? {
+																	bg: `gray.600`,
+																	color: `white`,
+																}
+															: {
+																	bg: `gray.500`,
+																	color: `white`,
+																}
+													}
+													minW={"32px"}
+													minH={"32px"}
+													maxW={"32px"}
+													maxH={"32px"}
+													rounded={"full"}
+													data-tip="Click to Save"
+													onClick={() =>
+														setIsEditingImplications(
+															false
+														)
+													}
+												>
+													<Icon
+														as={AiFillEyeInvisible}
+													/>
+												</Button>
+											</Flex>
+										</Box>
+									) : isHoveredImplications ? (
+										<Box
+											pos={"absolute"}
+											right={10}
+											top={0}
+										>
+											<Button
+												ml={2}
+												bg={
+													colorMode === "light"
+														? `gray.500`
+														: `gray.600`
+												}
+												color={
+													colorMode === "light"
+														? "whiteAlpha.900"
+														: "whiteAlpha.800"
+												}
+												_hover={
+													colorMode === "light"
+														? {
+																bg: `gray.600`,
+																color: `white`,
+															}
+														: {
+																bg: `gray.500`,
+																color: `white`,
+															}
+												}
+												minW={"32px"}
+												minH={"32px"}
+												maxW={"32px"}
+												maxH={"32px"}
+												rounded={"full"}
+												data-tip="Click to Save"
+												onClick={() =>
+													setIsEditingImplications(
+														true
+													)
+												}
+											>
+												<Icon as={AiFillEdit} />
+											</Button>
+										</Box>
+									) : null}
+								</Box>
+
+								<Box mt={"-15px"} className="editor-scroller">
+									<Box
+										//   className="editor"
+										//   ref={onRef}
+										style={{
+											// background: "red",
+											marginLeft: `${dragBtnMargin}px`,
+										}}
+									>
+										<ContentEditable
+											style={{
+												minHeight: "50px",
+												width: "100%",
+												height: "auto",
+												padding: "32px",
+												paddingBottom: "16px",
+												//   borderRadius: "0 0 25px 25px",
+												outline: "none",
+												marginLeft: -8,
+											}}
+
+											// autoFocus
+										/>
+									</Box>
+								</Box>
+								{/* <Box>Editor: {editorText}</Box> */}
+							</Box>
+						}
+						// placeholder={
+						//     isEditing ?
+						//         <Box
+						//             style={{
+						//                 position: "absolute",
+						//                 left: `${24 + dragBtnMargin}px`,
+						//                 top: `${75 + aboveContentHeight + toolBarHeight}px`,
+						//                 userSelect: "none",
+						//                 pointerEvents: "none",
+						//                 color: "gray",
+						//             }}
+						//         >
+						//             {`Enter text...`}
+						//         </Box>
+						//         : null
+						// }
+						ErrorBoundary={LexicalErrorBoundary}
+					/>
+
+					<TabIndentationPlugin />
+					<ListMaxIndentLevelPlugin maxDepth={3} />
+					<AutoFocusPlugin />
+				</LexicalComposer>
+
+				{/* Future Directions */}
+				<LexicalComposer
+					key={`future-${initialConfigFuture.editable}`}
+					initialConfig={initialConfigFuture}
+				>
+					{/* Plugins*/}
+					<TablePlugin
+						hasCellMerge={true}
+						hasCellBackgroundColor={false}
+					/>
+					<HistoryPlugin />
+					<ListPlugin />
+
+					<OnChangePlugin
+						onChange={(editorState, editor) => {
+							editorState.read(() => {
+								const root = $getRoot();
+
+								// setEditorText(root.__cachedText);
+								const newHtml = $generateHtmlFromNodes(
+									editor,
+									null
+								);
+								// setHtmlData(newHtml);
+								setFutureDirectionsDisplayData(newHtml);
+							});
+						}}
+					/>
+					{/* {data !== undefined && data !== null && ( */}
+					<PrepopulateHTMLPlugin data={futureDirectionsDisplayData} />
+					{/* )} */}
+					<CustomPastePlugin />
+
+					{/* Text Area */}
+					<RichTextPlugin
+						placeholder={<Text></Text>}
+						contentEditable={
+							<Box
+								mt={4}
+								onMouseOver={onMouseOverFuture}
+								onMouseLeave={onMouseOutFuture}
+								// bg={"red"}
+							>
+								{/* Toolbar */}
+								{isEditingFuture === false ? null : (
+									<RevisedRichTextToolbar />
+								)}
+
+								<Box pos={"relative"}>
+									<Text
+										fontWeight={"bold"}
+										fontSize={"lg"}
+										px={8}
+										ml={"2px"}
+										mt={4}
+										// userSelect={"none"}
+									>
+										Future Directions
+									</Text>
+
+									{isEditingFuture === true ? (
+										<Box
+											pos={"absolute"}
+											right={10}
+											top={0}
+										>
+											<Flex flexDir={"row"}>
+												<Button
+													bg={
+														colorMode === "light"
+															? `green.500`
+															: `green.600`
+													}
+													color={
+														colorMode === "light"
+															? "whiteAlpha.900"
+															: "whiteAlpha.800"
+													}
+													_hover={
+														colorMode === "light"
+															? {
+																	bg: `green.600`,
+																	color: `white`,
+																}
+															: {
+																	bg: `green.500`,
+																	color: `white`,
+																}
+													}
+													minW={"32px"}
+													minH={"32px"}
+													maxW={"32px"}
+													maxH={"32px"}
+													rounded={"full"}
+													data-tip="Click to Save"
+													onClick={() =>
+														onSave({
+															mainDocumentId:
+																fullPRData
+																	?.document
+																	?.pk,
+															section: "future",
+															htmlData:
+																futureDirectionsDisplayData,
+														})
+													}
+												>
+													<Icon as={FaSave} />
+												</Button>
+
+												<Button
+													ml={2}
+													bg={
+														colorMode === "light"
+															? `gray.500`
+															: `gray.600`
+													}
+													color={
+														colorMode === "light"
+															? "whiteAlpha.900"
+															: "whiteAlpha.800"
+													}
+													_hover={
+														colorMode === "light"
+															? {
+																	bg: `gray.600`,
+																	color: `white`,
+																}
+															: {
+																	bg: `gray.500`,
+																	color: `white`,
+																}
+													}
+													minW={"32px"}
+													minH={"32px"}
+													maxW={"32px"}
+													maxH={"32px"}
+													rounded={"full"}
+													data-tip="Click to Save"
+													onClick={() =>
+														setIsEditingFuture(
+															false
+														)
+													}
+												>
+													<Icon
+														as={AiFillEyeInvisible}
+													/>
+												</Button>
+											</Flex>
+										</Box>
+									) : isHoveredFuture ? (
+										<Box
+											pos={"absolute"}
+											right={10}
+											top={0}
+										>
+											<Button
+												ml={2}
+												bg={
+													colorMode === "light"
+														? `gray.500`
+														: `gray.600`
+												}
+												color={
+													colorMode === "light"
+														? "whiteAlpha.900"
+														: "whiteAlpha.800"
+												}
+												_hover={
+													colorMode === "light"
+														? {
+																bg: `gray.600`,
+																color: `white`,
+															}
+														: {
+																bg: `gray.500`,
+																color: `white`,
+															}
+												}
+												minW={"32px"}
+												minH={"32px"}
+												maxW={"32px"}
+												maxH={"32px"}
+												rounded={"full"}
+												data-tip="Click to Save"
+												onClick={() =>
+													setIsEditingFuture(true)
+												}
+											>
+												<Icon as={AiFillEdit} />
+											</Button>
+										</Box>
+									) : null}
+								</Box>
+
+								<Box mt={"-15px"} className="editor-scroller">
+									<Box
+										//   className="editor"
+										//   ref={onRef}
+										style={{
+											// background: "red",
+											marginLeft: `${dragBtnMargin}px`,
+										}}
+									>
+										<ContentEditable
+											style={{
+												minHeight: "50px",
+												width: "100%",
+												height: "auto",
+												padding: "32px",
+												paddingBottom: "16px",
+												//   borderRadius: "0 0 25px 25px",
+												outline: "none",
+												marginLeft: -8,
+											}}
+
+											// autoFocus
+										/>
+									</Box>
+								</Box>
+								{/* <Box>Editor: {editorText}</Box> */}
+							</Box>
+						}
+						// placeholder={
+						//     isEditing ?
+						//         <Box
+						//             style={{
+						//                 position: "absolute",
+						//                 left: `${24 + dragBtnMargin}px`,
+						//                 top: `${75 + aboveContentHeight + toolBarHeight}px`,
+						//                 userSelect: "none",
+						//                 pointerEvents: "none",
+						//                 color: "gray",
+						//             }}
+						//         >
+						//             {`Enter text...`}
+						//         </Box>
+						//         : null
+						// }
+						ErrorBoundary={LexicalErrorBoundary}
+					/>
+
+					<TabIndentationPlugin />
+					<ListMaxIndentLevelPlugin maxDepth={3} />
+					<AutoFocusPlugin />
+				</LexicalComposer>
+			</Box>
+		</>
+	);
 };

--- a/src/components/RichTextEditor/Editors/SREditor.tsx
+++ b/src/components/RichTextEditor/Editors/SREditor.tsx
@@ -2,22 +2,22 @@ import { ExtractedHTMLTitle } from "@/components/ExtractedHTMLTitle";
 import { ISaveStudentReport, updateStudentReportProgress } from "@/lib/api";
 import { IProjectData, IProjectMember } from "@/types";
 import {
-  Box,
-  Button,
-  Flex,
-  Icon,
-  Image,
-  Text,
-  ToastId,
-  useColorMode,
-  useDisclosure,
-  useToast,
+	Box,
+	Button,
+	Flex,
+	Icon,
+	Image,
+	Text,
+	ToastId,
+	useColorMode,
+	useDisclosure,
+	useToast,
 } from "@chakra-ui/react";
 import { $generateHtmlFromNodes } from "@lexical/html";
 import { AutoFocusPlugin } from "@lexical/react/LexicalAutoFocusPlugin";
 import {
-  InitialConfigType,
-  LexicalComposer,
+	InitialConfigType,
+	LexicalComposer,
 } from "@lexical/react/LexicalComposer";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import LexicalErrorBoundary from "@lexical/react/LexicalErrorBoundary";
@@ -46,555 +46,663 @@ import { ApproveProgressReportModal } from "@/components/Modals/RTEModals/Approv
 import { useNoImage } from "@/lib/hooks/helper/useNoImage";
 
 interface ISREditorProps {
-  isEditing: boolean;
-  setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
-  canEdit: boolean;
-  shouldAlternatePicture: boolean;
-  fullSRData: IStudentReportDisplayData;
-  initialConfig: InitialConfigType;
-  displayData: string;
-  setDisplayData: React.Dispatch<React.SetStateAction<string>>;
-  // key: string;
+	isEditing: boolean;
+	setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
+	canEdit: boolean;
+	shouldAlternatePicture: boolean;
+	fullSRData: IStudentReportDisplayData;
+	initialConfig: InitialConfigType;
+	displayData: string;
+	setDisplayData: React.Dispatch<React.SetStateAction<string>>;
+	// key: string;
 }
 
 interface ISRProjDetails {
-  project: IProjectData;
-  team_members: IProjectMember[];
+	project: IProjectData;
+	team_members: IProjectMember[];
 }
 const SRProjDetails = ({ project, team_members }: ISRProjDetails) => {
-  const getMembersByRole = (teamMembers, role) => {
-    return Array.from(teamMembers)
-      .filter((member: IProjectMember) => member.role === role)
-      .map(
-        (member: IProjectMember) =>
-          `${member.user.first_name} ${member.user.last_name}`
-      );
-  };
+	const getMembersByRole = (teamMembers, role) => {
+		return Array.from(teamMembers)
+			.filter((member: IProjectMember) => member.role === role)
+			.map(
+				(member: IProjectMember) =>
+					`${member.user.first_name} ${member.user.last_name}`
+			);
+	};
 
-  const students = getMembersByRole(team_members, "student");
-  const academicSupervisors = getMembersByRole(team_members, "academicsuper");
-  const scientists = getMembersByRole(team_members, "supervising");
+	const students = getMembersByRole(team_members, "student");
+	const academicSupervisors = getMembersByRole(team_members, "academicsuper");
+	const scientists = getMembersByRole(team_members, "supervising");
 
-  return (
-    <Box py={3}>
-      <Flex mb={0.5} flexWrap={"wrap"}>
-        <Text fontWeight={"semibold"} mr={1}>
-          Tag:{" "}
-        </Text>
-        <Text>{`STP-${project?.year}-${project?.number}`}</Text>
-      </Flex>
-      <Flex mb={0.5} flexWrap={"wrap"}>
-        <Text fontWeight={"semibold"} mr={1}>
-          Student:
-        </Text>
-        <Text>{students.join(", ")}</Text>
-      </Flex>
-      <Flex mb={0.5} flexWrap={"wrap"}>
-        <Text fontWeight={"semibold"} mr={1}>
-          Academics:{" "}
-        </Text>
-        <Text>{academicSupervisors.join(", ")}</Text>
-      </Flex>
-      <Flex mb={0.5} flexWrap={"wrap"}>
-        <Text fontWeight={"semibold"} mr={1}>
-          Scientists:{" "}
-        </Text>
-        <Text>{scientists.join(", ")}</Text>
-      </Flex>
-    </Box>
-  );
+	return (
+		<Box py={3}>
+			<Flex mb={0.5} flexWrap={"wrap"}>
+				<Text
+					fontWeight={"semibold"}
+					mr={1}
+					color={
+						project?.status === "completed" ||
+						project?.status === "terminated"
+							? "green.500"
+							: project?.status === "updating"
+								? "red.500"
+								: project?.status === "suspended"
+									? "orange.500"
+									: undefined
+					}
+				>
+					Status:{" "}
+				</Text>
+				<Text
+					color={
+						project?.status === "completed" ||
+						project?.status === "terminated"
+							? "green.500"
+							: project?.status === "updating"
+								? "red.500"
+								: project?.status === "suspended"
+									? "orange.500"
+									: undefined
+					}
+				>
+					{`${project?.status[0].toUpperCase()}${project?.status.slice(1)}`}
+				</Text>
+			</Flex>
+			<Flex mb={0.5} flexWrap={"wrap"}>
+				<Text fontWeight={"semibold"} mr={1}>
+					Tag:{" "}
+				</Text>
+				<Text>{`STP-${project?.year}-${project?.number}`}</Text>
+			</Flex>
+			<Flex mb={0.5} flexWrap={"wrap"}>
+				<Text fontWeight={"semibold"} mr={1}>
+					Student:
+				</Text>
+				<Text>{students.join(", ")}</Text>
+			</Flex>
+			<Flex mb={0.5} flexWrap={"wrap"}>
+				<Text fontWeight={"semibold"} mr={1}>
+					Academics:{" "}
+				</Text>
+				<Text>{academicSupervisors.join(", ")}</Text>
+			</Flex>
+			<Flex mb={0.5} flexWrap={"wrap"}>
+				<Text fontWeight={"semibold"} mr={1}>
+					Scientists:{" "}
+				</Text>
+				<Text>{scientists.join(", ")}</Text>
+			</Flex>
+		</Box>
+	);
 };
 
 export const SREditor = ({
-  shouldAlternatePicture,
-  fullSRData,
-  initialConfig,
-  isEditing,
-  setIsEditing,
-  canEdit,
-  displayData,
-  setDisplayData,
+	shouldAlternatePicture,
+	fullSRData,
+	initialConfig,
+	isEditing,
+	setIsEditing,
+	canEdit,
+	displayData,
+	setDisplayData,
 }: // key
 ISREditorProps) => {
-  // const navigate = useNavigate();
-  const { colorMode } = useColorMode();
+	// const navigate = useNavigate();
+	const { colorMode } = useColorMode();
 
-  // const editorInstance = useLexicalComposerContext();
+	// const editorInstance = useLexicalComposerContext();
 
-  // useEffect(() => {
+	// useEffect(() => {
 
-  //     if (editorInstance) {
-  //       // Perform operations on the Lexical editor instance
-  //       const root = editorInstance.$getRoot();
-  //       setEditorText(root.__cachedText);
-  //     }
-  //   }, [editorRef, setEditorText]);
+	//     if (editorInstance) {
+	//       // Perform operations on the Lexical editor instance
+	//       const root = editorInstance.$getRoot();
+	//       setEditorText(root.__cachedText);
+	//     }
+	//   }, [editorRef, setEditorText]);
 
-  const dragBtnMargin = 10;
-  const toolBarHeight = 45;
-  const [aboveHeightSet, setAboveHeightSet] = useState<boolean>(false);
-  const [aboveContentHeight, setAboveContentHeight] = useState<number>();
+	const dragBtnMargin = 10;
+	const toolBarHeight = 45;
+	const [aboveHeightSet, setAboveHeightSet] = useState<boolean>(false);
+	const [aboveContentHeight, setAboveContentHeight] = useState<number>();
 
-  // const [htmlData, setHtmlData] = useState(fullSRData?.progress_report);
-  const [isHovered, setIsHovered] = useState(false);
+	// const [htmlData, setHtmlData] = useState(fullSRData?.progress_report);
+	const [isHovered, setIsHovered] = useState(false);
 
-  const onMouseOver = () => {
-    if (!isHovered) {
-      setIsHovered(true);
-    }
-  };
+	const onMouseOver = () => {
+		if (!isHovered) {
+			setIsHovered(true);
+		}
+	};
 
-  const onMouseOut = () => {
-    if (isHovered) {
-      setIsHovered(false);
-    }
-  };
+	const onMouseOut = () => {
+		if (isHovered) {
+			setIsHovered(false);
+		}
+	};
 
-  useEffect(() => {
-    setAboveHeightSet(false);
-    const calculateAboveContentHeight = () => {
-      const aboveContentElement = document.getElementById(
-        `topContent_${fullSRData?.document?.project?.pk}`
-      );
+	useEffect(() => {
+		setAboveHeightSet(false);
+		const calculateAboveContentHeight = () => {
+			const aboveContentElement = document.getElementById(
+				`topContent_${fullSRData?.document?.project?.pk}`
+			);
 
-      if (aboveContentElement) {
-        const rect = aboveContentElement.getBoundingClientRect();
-        const contentAboveHeight = rect.bottom - rect.top;
-        setAboveContentHeight(contentAboveHeight);
-      }
-    };
+			if (aboveContentElement) {
+				const rect = aboveContentElement.getBoundingClientRect();
+				const contentAboveHeight = rect.bottom - rect.top;
+				setAboveContentHeight(contentAboveHeight);
+			}
+		};
 
-    // Call the function initially
-    calculateAboveContentHeight();
+		// Call the function initially
+		calculateAboveContentHeight();
 
-    // Attach resize event listener to recalculate height when the window is resized
-    window.addEventListener("resize", calculateAboveContentHeight);
-    setAboveHeightSet(true);
+		// Attach resize event listener to recalculate height when the window is resized
+		window.addEventListener("resize", calculateAboveContentHeight);
+		setAboveHeightSet(true);
 
-    // Cleanup event listener on component unmount
-    return () => {
-      window.removeEventListener("resize", calculateAboveContentHeight);
-    };
-  }, [
-    displayData,
-    isEditing,
-    fullSRData?.document?.project?.pk,
-    initialConfig,
-  ]);
+		// Cleanup event listener on component unmount
+		return () => {
+			window.removeEventListener("resize", calculateAboveContentHeight);
+		};
+	}, [
+		displayData,
+		isEditing,
+		fullSRData?.document?.project?.pk,
+		initialConfig,
+	]);
 
-  const queryClient = useQueryClient();
-  const { register, handleSubmit, reset } = useForm<ISaveStudentReport>();
-  const toast = useToast();
-  const toastIdRef = useRef<ToastId>();
-  const addToast = (data) => {
-    toastIdRef.current = toast(data);
-  };
+	const queryClient = useQueryClient();
+	const { register, handleSubmit, reset } = useForm<ISaveStudentReport>();
+	const toast = useToast();
+	const toastIdRef = useRef<ToastId>();
+	const addToast = (data) => {
+		toastIdRef.current = toast(data);
+	};
 
-  const saveMutation = useMutation({
-    mutationFn: updateStudentReportProgress,
-    onMutate: () => {
-      addToast({
-        status: "loading",
-        title: "Saving Student Report",
-        position: "top-right",
-      });
-    },
-    onSuccess: () => {
-      if (toastIdRef.current) {
-        toast.update(toastIdRef.current, {
-          title: "Success",
-          description: `Student Report Saved`,
-          status: "success",
-          position: "top-right",
-          duration: 3000,
-          isClosable: true,
-        });
-      }
-      // reset();
+	const saveMutation = useMutation({
+		mutationFn: updateStudentReportProgress,
+		onMutate: () => {
+			addToast({
+				status: "loading",
+				title: "Saving Student Report",
+				position: "top-right",
+			});
+		},
+		onSuccess: () => {
+			if (toastIdRef.current) {
+				toast.update(toastIdRef.current, {
+					title: "Success",
+					description: `Student Report Saved`,
+					status: "success",
+					position: "top-right",
+					duration: 3000,
+					isClosable: true,
+				});
+			}
+			// reset();
 
-      // setTimeout(() => {
-      //   queryClient.invalidateQueries(["mytasks"]);
-      // }, 350);
-    },
-    onError: (error) => {
-      if (toastIdRef.current) {
-        toast.update(toastIdRef.current, {
-          title: "Could Not Save Student Progress Report",
-          description: `${error}`,
-          status: "error",
-          position: "top-right",
-          duration: 3000,
-          isClosable: true,
-        });
-      }
-    },
-  });
+			// setTimeout(() => {
+			//   queryClient.invalidateQueries(["mytasks"]);
+			// }, 350);
+		},
+		onError: (error) => {
+			if (toastIdRef.current) {
+				toast.update(toastIdRef.current, {
+					title: "Could Not Save Student Progress Report",
+					description: `${error}`,
+					status: "error",
+					position: "top-right",
+					duration: 3000,
+					isClosable: true,
+				});
+			}
+		},
+	});
 
-  const onSave = (formData: ISaveStudentReport) => {
-    saveMutation.mutate(formData);
-    setIsEditing(false);
-  };
+	const onSave = (formData: ISaveStudentReport) => {
+		saveMutation.mutate(formData);
+		setIsEditing(false);
+	};
 
-  const {
-    isOpen: isApproveProgressReportOpen,
-    onOpen: onOpenApproveProgressReport,
-    onClose: onCloseApproveProgressReport,
-  } = useDisclosure();
+	const {
+		isOpen: isApproveProgressReportOpen,
+		onOpen: onOpenApproveProgressReport,
+		onClose: onCloseApproveProgressReport,
+	} = useDisclosure();
 
-  const [isActive, setIsActive] = useState(
-    fullSRData?.document?.project?.status === "active"
-  );
-  useEffect(() => {
-    setIsActive(fullSRData?.document?.project?.status === "active");
-  }, [fullSRData]);
+	const [isActive, setIsActive] = useState(
+		fullSRData?.document?.project?.status === "active"
+	);
+	useEffect(() => {
+		setIsActive(fullSRData?.document?.project?.status === "active");
+	}, [fullSRData]);
 
-  const noImage = useNoImage();
+	const noImage = useNoImage();
 
-  return (
-    <>
-      {/* setIsEditing */}
-      <ApproveProgressReportModal
-        isActive={isActive}
-        report={fullSRData}
-        isOpen={isApproveProgressReportOpen}
-        onClose={onCloseApproveProgressReport}
-      />
-      <Box
-        mx={4}
-        pos={"relative"}
-        roundedBottom={20}
-        roundedTop={20}
-        mb={4}
-        boxShadow={
-          "0 8px 24px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.1)"
-        }
-        bg={colorMode === "light" ? "whiteAlpha.600" : "blackAlpha.500"}
-        onMouseOver={onMouseOver}
-        onMouseLeave={onMouseOut}
-      >
-        <Flex
-          id={`topContent_${fullSRData?.document?.project?.pk}`}
-          pt={6}
-          mx={8}
-        >
-          {!shouldAlternatePicture ? (
-            <>
-              <Box rounded={"md"} overflow={"hidden"} w={"276px"} h={"200px"}>
-                <Image
-                  src={fullSRData?.document?.project?.image?.file ?? noImage}
-                  w={"100%"}
-                  h={"100%"}
-                  objectFit={"cover"}
-                />
-              </Box>
-              <Box ml={4} flex={1}>
-                <Box>
-                  <ExtractedHTMLTitle
-                    htmlContent={fullSRData?.document?.project?.title}
-                    color={"blue.500"}
-                    fontWeight={"bold"}
-                    fontSize={"17px"}
-                    // fontSize={"xs"}
-                    noOfLines={4}
-                    cursor={"pointer"}
-                    onClick={() => {
-                      const url = `/projects/${fullSRData?.document?.project?.pk}/student`;
-                      window.open(url, "_blank");
-                      // navigate(url);
-                    }}
-                  />
-                </Box>
+	return (
+		<>
+			{/* setIsEditing */}
+			<ApproveProgressReportModal
+				isActive={isActive}
+				report={fullSRData}
+				isOpen={isApproveProgressReportOpen}
+				onClose={onCloseApproveProgressReport}
+			/>
+			<Box
+				mx={4}
+				pos={"relative"}
+				roundedBottom={20}
+				roundedTop={20}
+				mb={4}
+				boxShadow={
+					"0 8px 24px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.1)"
+				}
+				bg={colorMode === "light" ? "whiteAlpha.600" : "blackAlpha.500"}
+				onMouseOver={onMouseOver}
+				onMouseLeave={onMouseOut}
+			>
+				<Flex
+					id={`topContent_${fullSRData?.document?.project?.pk}`}
+					pt={6}
+					mx={8}
+				>
+					{!shouldAlternatePicture ? (
+						<>
+							<Box
+								rounded={"md"}
+								overflow={"hidden"}
+								w={"276px"}
+								h={"200px"}
+							>
+								<Image
+									src={
+										fullSRData?.document?.project?.image
+											?.file ?? noImage
+									}
+									w={"100%"}
+									h={"100%"}
+									objectFit={"cover"}
+								/>
+							</Box>
+							<Box ml={4} flex={1}>
+								<Box>
+									<ExtractedHTMLTitle
+										htmlContent={
+											fullSRData?.document?.project?.title
+										}
+										color={"blue.500"}
+										fontWeight={"bold"}
+										fontSize={"17px"}
+										// fontSize={"xs"}
+										noOfLines={4}
+										cursor={"pointer"}
+										onClick={() => {
+											const url = `/projects/${fullSRData?.document?.project?.pk}/student`;
+											window.open(url, "_blank");
+											// navigate(url);
+										}}
+									/>
+								</Box>
 
-                <SRProjDetails
-                  project={fullSRData?.document?.project}
-                  team_members={fullSRData?.team_members}
-                />
-              </Box>
-            </>
-          ) : (
-            <>
-              <Box mr={4} flex={1}>
-                <Box>
-                  <ExtractedHTMLTitle
-                    htmlContent={fullSRData?.document?.project?.title}
-                    color={"blue.500"}
-                    fontWeight={"bold"}
-                    fontSize={"17px"}
-                    // fontSize={"xs"}
-                    noOfLines={4}
-                    cursor={"pointer"}
-                    onClick={() => {
-                      const url = `/projects/${fullSRData?.document?.project?.pk}/student`;
-                      window.open(url, "_blank");
-                      // navigate(url);
-                    }}
-                  />
-                </Box>
+								<SRProjDetails
+									project={fullSRData?.document?.project}
+									team_members={fullSRData?.team_members}
+								/>
+							</Box>
+						</>
+					) : (
+						<>
+							<Box mr={4} flex={1}>
+								<Box>
+									<ExtractedHTMLTitle
+										htmlContent={
+											fullSRData?.document?.project?.title
+										}
+										color={"blue.500"}
+										fontWeight={"bold"}
+										fontSize={"17px"}
+										// fontSize={"xs"}
+										noOfLines={4}
+										cursor={"pointer"}
+										onClick={() => {
+											const url = `/projects/${fullSRData?.document?.project?.pk}/student`;
+											window.open(url, "_blank");
+											// navigate(url);
+										}}
+									/>
+								</Box>
 
-                <SRProjDetails
-                  project={fullSRData?.document?.project}
-                  team_members={fullSRData?.team_members}
-                />
-              </Box>
-              <Box rounded={"md"} overflow={"hidden"} w={"276px"} h={"200px"}>
-                <Image
-                  src={fullSRData?.document?.project?.image?.file ?? noImage}
-                  w={"100%"}
-                  h={"100%"}
-                  objectFit={"cover"}
-                />
-              </Box>
-            </>
-          )}
-        </Flex>
+								<SRProjDetails
+									project={fullSRData?.document?.project}
+									team_members={fullSRData?.team_members}
+								/>
+							</Box>
+							<Box
+								rounded={"md"}
+								overflow={"hidden"}
+								w={"276px"}
+								h={"200px"}
+							>
+								<Image
+									src={
+										fullSRData?.document?.project?.image
+											?.file ?? noImage
+									}
+									w={"100%"}
+									h={"100%"}
+									objectFit={"cover"}
+								/>
+							</Box>
+						</>
+					)}
+				</Flex>
 
-        <LexicalComposer initialConfig={initialConfig}>
-          {/* Plugins*/}
-          <TablePlugin hasCellMerge={true} hasCellBackgroundColor={false} />
-          <HistoryPlugin />
-          <ListPlugin />
+				<LexicalComposer initialConfig={initialConfig}>
+					{/* Plugins*/}
+					<TablePlugin
+						hasCellMerge={true}
+						hasCellBackgroundColor={false}
+					/>
+					<HistoryPlugin />
+					<ListPlugin />
 
-          <OnChangePlugin
-            onChange={(editorState, editor) => {
-              editorState.read(() => {
-                const root = $getRoot();
+					<OnChangePlugin
+						onChange={(editorState, editor) => {
+							editorState.read(() => {
+								const root = $getRoot();
 
-                // setEditorText(root.__cachedText);
-                const newHtml = $generateHtmlFromNodes(editor, null);
-                // setHtmlData(newHtml);
-                setDisplayData(newHtml);
-              });
-            }}
-          />
-          {/* {data !== undefined && data !== null && ( */}
-          <PrepopulateHTMLPlugin data={displayData} />
-          {/* )} */}
-          <CustomPastePlugin />
+								// setEditorText(root.__cachedText);
+								const newHtml = $generateHtmlFromNodes(
+									editor,
+									null
+								);
+								// setHtmlData(newHtml);
+								setDisplayData(newHtml);
+							});
+						}}
+					/>
+					{/* {data !== undefined && data !== null && ( */}
+					<PrepopulateHTMLPlugin data={displayData} />
+					{/* )} */}
+					<CustomPastePlugin />
 
-          {/* Text Area */}
-          <RichTextPlugin
-            placeholder={<Text></Text>}
-            contentEditable={
-              <Box
-                mt={4}
-                // bg={"red"}
-              >
-                {/* Toolbar */}
-                {isEditing === false ? null : <RevisedRichTextToolbar />}
+					{/* Text Area */}
+					<RichTextPlugin
+						placeholder={<Text></Text>}
+						contentEditable={
+							<Box
+								mt={4}
+								// bg={"red"}
+							>
+								{/* Toolbar */}
+								{isEditing === false ? null : (
+									<RevisedRichTextToolbar />
+								)}
 
-                <Box pos={"relative"}>
-                  <Text
-                    fontWeight={"bold"}
-                    fontSize={"lg"}
-                    px={8}
-                    ml={"2px"}
-                    mt={4}
-                    // userSelect={"none"}
-                  >
-                    Progress Report
-                  </Text>
+								<Box pos={"relative"}>
+									<Text
+										fontWeight={"bold"}
+										fontSize={"lg"}
+										px={8}
+										ml={"2px"}
+										mt={4}
+										// userSelect={"none"}
+									>
+										Progress Report
+									</Text>
 
-                  {isEditing === true ? (
-                    <Box pos={"absolute"} right={10} top={0}>
-                      <Flex flexDir={"row"}>
-                        <Button
-                          bg={colorMode === "light" ? `green.500` : `green.600`}
-                          color={
-                            colorMode === "light"
-                              ? "whiteAlpha.900"
-                              : "whiteAlpha.800"
-                          }
-                          _hover={
-                            colorMode === "light"
-                              ? {
-                                  bg: `green.600`,
-                                  color: `white`,
-                                }
-                              : {
-                                  bg: `green.500`,
-                                  color: `white`,
-                                }
-                          }
-                          minW={"32px"}
-                          minH={"32px"}
-                          maxW={"32px"}
-                          maxH={"32px"}
-                          rounded={"full"}
-                          data-tip="Click to Save"
-                          onClick={() =>
-                            onSave({
-                              mainDocumentId: fullSRData?.document?.pk,
-                              progressReportHtml: displayData,
-                            })
-                          }
-                        >
-                          <Icon as={FaSave} />
-                        </Button>
+									{isEditing === true ? (
+										<Box
+											pos={"absolute"}
+											right={10}
+											top={0}
+										>
+											<Flex flexDir={"row"}>
+												<Button
+													bg={
+														colorMode === "light"
+															? `green.500`
+															: `green.600`
+													}
+													color={
+														colorMode === "light"
+															? "whiteAlpha.900"
+															: "whiteAlpha.800"
+													}
+													_hover={
+														colorMode === "light"
+															? {
+																	bg: `green.600`,
+																	color: `white`,
+																}
+															: {
+																	bg: `green.500`,
+																	color: `white`,
+																}
+													}
+													minW={"32px"}
+													minH={"32px"}
+													maxW={"32px"}
+													maxH={"32px"}
+													rounded={"full"}
+													data-tip="Click to Save"
+													onClick={() =>
+														onSave({
+															mainDocumentId:
+																fullSRData
+																	?.document
+																	?.pk,
+															progressReportHtml:
+																displayData,
+														})
+													}
+												>
+													<Icon as={FaSave} />
+												</Button>
 
-                        <Button
-                          ml={2}
-                          bg={colorMode === "light" ? `gray.500` : `gray.600`}
-                          color={
-                            colorMode === "light"
-                              ? "whiteAlpha.900"
-                              : "whiteAlpha.800"
-                          }
-                          _hover={
-                            colorMode === "light"
-                              ? {
-                                  bg: `gray.600`,
-                                  color: `white`,
-                                }
-                              : {
-                                  bg: `gray.500`,
-                                  color: `white`,
-                                }
-                          }
-                          minW={"32px"}
-                          minH={"32px"}
-                          maxW={"32px"}
-                          maxH={"32px"}
-                          rounded={"full"}
-                          data-tip="Click to Save"
-                          onClick={() => setIsEditing(false)}
-                        >
-                          <Icon as={AiFillEyeInvisible} />
-                        </Button>
-                      </Flex>
-                    </Box>
-                  ) : isHovered ? (
-                    <>
-                      <Box pos={"absolute"} right={8} top={0}>
-                        <Button
-                          ml={2}
-                          bg={
-                            isActive
-                              ? colorMode === "light"
-                                ? `orange.500`
-                                : `orange.600`
-                              : colorMode === "light"
-                              ? `green.500`
-                              : `green.600`
-                          }
-                          color={
-                            colorMode === "light"
-                              ? "whiteAlpha.900"
-                              : "whiteAlpha.800"
-                          }
-                          _hover={
-                            colorMode === "light"
-                              ? {
-                                  bg: isActive ? `orange.600` : `green.600`,
-                                  color: `white`,
-                                }
-                              : {
-                                  bg: isActive ? `orange.500` : `green.500`,
-                                  color: `white`,
-                                }
-                          }
-                          minW={"32px"}
-                          minH={"32px"}
-                          maxW={"32px"}
-                          maxH={"32px"}
-                          rounded={"full"}
-                          data-tip="Click to edit"
-                          onClick={onOpenApproveProgressReport}
-                        >
-                          <Icon as={isActive ? FaUndo : TiTick} />
-                        </Button>
-                      </Box>
-                      <Box pos={"absolute"} right={20} top={0}>
-                        <Button
-                          ml={2}
-                          bg={colorMode === "light" ? `gray.500` : `gray.600`}
-                          color={
-                            colorMode === "light"
-                              ? "whiteAlpha.900"
-                              : "whiteAlpha.800"
-                          }
-                          _hover={
-                            colorMode === "light"
-                              ? {
-                                  bg: `gray.600`,
-                                  color: `white`,
-                                }
-                              : {
-                                  bg: `gray.500`,
-                                  color: `white`,
-                                }
-                          }
-                          minW={"32px"}
-                          minH={"32px"}
-                          maxW={"32px"}
-                          maxH={"32px"}
-                          rounded={"full"}
-                          data-tip="Click to Save"
-                          onClick={() => setIsEditing(true)}
-                        >
-                          <Icon as={AiFillEdit} />
-                        </Button>
-                      </Box>
-                    </>
-                  ) : null}
-                </Box>
+												<Button
+													ml={2}
+													bg={
+														colorMode === "light"
+															? `gray.500`
+															: `gray.600`
+													}
+													color={
+														colorMode === "light"
+															? "whiteAlpha.900"
+															: "whiteAlpha.800"
+													}
+													_hover={
+														colorMode === "light"
+															? {
+																	bg: `gray.600`,
+																	color: `white`,
+																}
+															: {
+																	bg: `gray.500`,
+																	color: `white`,
+																}
+													}
+													minW={"32px"}
+													minH={"32px"}
+													maxW={"32px"}
+													maxH={"32px"}
+													rounded={"full"}
+													data-tip="Click to Save"
+													onClick={() =>
+														setIsEditing(false)
+													}
+												>
+													<Icon
+														as={AiFillEyeInvisible}
+													/>
+												</Button>
+											</Flex>
+										</Box>
+									) : isHovered ? (
+										<>
+											<Box
+												pos={"absolute"}
+												right={8}
+												top={0}
+											>
+												<Button
+													ml={2}
+													bg={
+														isActive
+															? colorMode ===
+																"light"
+																? `orange.500`
+																: `orange.600`
+															: colorMode ===
+																  "light"
+																? `green.500`
+																: `green.600`
+													}
+													color={
+														colorMode === "light"
+															? "whiteAlpha.900"
+															: "whiteAlpha.800"
+													}
+													_hover={
+														colorMode === "light"
+															? {
+																	bg: isActive
+																		? `orange.600`
+																		: `green.600`,
+																	color: `white`,
+																}
+															: {
+																	bg: isActive
+																		? `orange.500`
+																		: `green.500`,
+																	color: `white`,
+																}
+													}
+													minW={"32px"}
+													minH={"32px"}
+													maxW={"32px"}
+													maxH={"32px"}
+													rounded={"full"}
+													data-tip="Click to edit"
+													onClick={
+														onOpenApproveProgressReport
+													}
+												>
+													<Icon
+														as={
+															isActive
+																? FaUndo
+																: TiTick
+														}
+													/>
+												</Button>
+											</Box>
+											<Box
+												pos={"absolute"}
+												right={20}
+												top={0}
+											>
+												<Button
+													ml={2}
+													bg={
+														colorMode === "light"
+															? `gray.500`
+															: `gray.600`
+													}
+													color={
+														colorMode === "light"
+															? "whiteAlpha.900"
+															: "whiteAlpha.800"
+													}
+													_hover={
+														colorMode === "light"
+															? {
+																	bg: `gray.600`,
+																	color: `white`,
+																}
+															: {
+																	bg: `gray.500`,
+																	color: `white`,
+																}
+													}
+													minW={"32px"}
+													minH={"32px"}
+													maxW={"32px"}
+													maxH={"32px"}
+													rounded={"full"}
+													data-tip="Click to Save"
+													onClick={() =>
+														setIsEditing(true)
+													}
+												>
+													<Icon as={AiFillEdit} />
+												</Button>
+											</Box>
+										</>
+									) : null}
+								</Box>
 
-                <Box mt={"-15px"} className="editor-scroller">
-                  <Box
-                    //   className="editor"
-                    //   ref={onRef}
-                    style={{
-                      // background: "red",
-                      marginLeft: `${dragBtnMargin}px`,
-                    }}
-                  >
-                    <ContentEditable
-                      style={{
-                        minHeight: "50px",
-                        width: "100%",
-                        height: "auto",
-                        padding: "32px",
-                        paddingBottom: "16px",
-                        //   borderRadius: "0 0 25px 25px",
-                        outline: "none",
-                        marginLeft: -8,
-                      }}
+								<Box mt={"-15px"} className="editor-scroller">
+									<Box
+										//   className="editor"
+										//   ref={onRef}
+										style={{
+											// background: "red",
+											marginLeft: `${dragBtnMargin}px`,
+										}}
+									>
+										<ContentEditable
+											style={{
+												minHeight: "50px",
+												width: "100%",
+												height: "auto",
+												padding: "32px",
+												paddingBottom: "16px",
+												//   borderRadius: "0 0 25px 25px",
+												outline: "none",
+												marginLeft: -8,
+											}}
 
-                      // autoFocus
-                    />
-                  </Box>
-                </Box>
-                {/* <Box>Editor: {editorText}</Box> */}
-              </Box>
-            }
-            // placeholder={
-            //     isEditing ?
-            //         <Box
-            //             style={{
-            //                 position: "absolute",
-            //                 left: `${24 + dragBtnMargin}px`,
-            //                 top: `${75 + aboveContentHeight + toolBarHeight}px`,
-            //                 userSelect: "none",
-            //                 pointerEvents: "none",
-            //                 color: "gray",
-            //             }}
-            //         >
-            //             {`Enter text...`}
-            //         </Box>
-            //         : null
-            // }
-            ErrorBoundary={LexicalErrorBoundary}
-          />
-          <TabIndentationPlugin />
-          <ListMaxIndentLevelPlugin maxDepth={3} />
-          <AutoFocusPlugin />
-        </LexicalComposer>
-      </Box>
-    </>
-  );
+											// autoFocus
+										/>
+									</Box>
+								</Box>
+								{/* <Box>Editor: {editorText}</Box> */}
+							</Box>
+						}
+						// placeholder={
+						//     isEditing ?
+						//         <Box
+						//             style={{
+						//                 position: "absolute",
+						//                 left: `${24 + dragBtnMargin}px`,
+						//                 top: `${75 + aboveContentHeight + toolBarHeight}px`,
+						//                 userSelect: "none",
+						//                 pointerEvents: "none",
+						//                 color: "gray",
+						//             }}
+						//         >
+						//             {`Enter text...`}
+						//         </Box>
+						//         : null
+						// }
+						ErrorBoundary={LexicalErrorBoundary}
+					/>
+					<TabIndentationPlugin />
+					<ListMaxIndentLevelPlugin maxDepth={3} />
+					<AutoFocusPlugin />
+				</LexicalComposer>
+			</Box>
+		</>
+	);
 };
 
 {
-  /* <Flex mx={8} mt={4} pt={8}>
+	/* <Flex mx={8} mt={4} pt={8}>
           {!shouldAlternatePicture ? (
             <>
               <Box rounded={"md"} overflow={"hidden"} w={"276px"} h={"200px"}>
@@ -691,7 +799,7 @@ ISREditorProps) => {
         </Flex> */
 }
 {
-  /* <ARProgressReportEditor
+	/* <ARProgressReportEditor
                 initialConfig={initialConfig}
                 editorRef={editorRef}
                 // context_prepopulation_data={


### PR DESCRIPTION
Now based on the status of the progress report document when generating PDFs, rather than the project it belongs to - ensures no closed, terminated, suspended etc prs missed.

fixes #261