### PR TITLE
fix: resolve project closure document management bugs

### DIFF
--- a/backend/documents/services/approval_service.py
+++ b/backend/documents/services/approval_service.py
@@ -247,7 +247,7 @@ class ApprovalService:
 
     @staticmethod
     @transaction.atomic
-    def send_back(document, sender, feedback_html=""):
+    def send_back(document, sender, feedback_html="", send_notifications=True):
         """
         Send document back for revision
 
@@ -259,6 +259,7 @@ class ApprovalService:
             document: ProjectDocument instance
             sender: User sending back the document
             feedback_html: Optional rich text HTML feedback (shown in email)
+            send_notifications: Whether to send notification emails
         """
         settings.LOGGER.info(f"{sender} is sending back document {document}")
 
@@ -293,18 +294,22 @@ class ApprovalService:
         document.status = ProjectDocument.StatusChoices.REVISING
         document.save()
 
-        try:
-            NotificationService.notify_document_sent_back(
-                document, sender, feedback_html
-            )
-        except Exception as e:
-            settings.LOGGER.error(
-                f"Failed to send document sent back notification: {e}", exc_info=True
-            )
+        if send_notifications:
+            try:
+                NotificationService.notify_document_sent_back(
+                    document, sender, feedback_html
+                )
+            except Exception as e:
+                settings.LOGGER.error(
+                    f"Failed to send document sent back notification: {e}",
+                    exc_info=True,
+                )
 
     @staticmethod
     @transaction.atomic
-    def recall(document, recaller, feedback_html="", stage=None):
+    def recall(
+        document, recaller, feedback_html="", stage=None, send_notifications=True
+    ):
         """
         Recall document from approval process.
 
@@ -320,6 +325,7 @@ class ApprovalService:
             recaller: User recalling the document
             feedback_html: Optional rich text HTML feedback (shown in email)
             stage: The approval stage being recalled (1, 2, or 3)
+            send_notifications: Whether to send notification emails
         """
         settings.LOGGER.info(
             f"{recaller} is recalling document {document} at stage {stage}"
@@ -368,14 +374,15 @@ class ApprovalService:
 
         document.save()
 
-        try:
-            NotificationService.notify_document_recalled(
-                document, recaller, feedback_html
-            )
-        except Exception as e:
-            settings.LOGGER.error(
-                f"Failed to send document recalled notification: {e}", exc_info=True
-            )
+        if send_notifications:
+            try:
+                NotificationService.notify_document_recalled(
+                    document, recaller, feedback_html
+                )
+            except Exception as e:
+                settings.LOGGER.error(
+                    f"Failed to send document recalled notification: {e}", exc_info=True
+                )
 
     @staticmethod
     def _revert_stage_three_project_status(document):

--- a/backend/documents/services/notification_service.py
+++ b/backend/documents/services/notification_service.py
@@ -1379,13 +1379,14 @@ class NotificationService:
         )
 
     @staticmethod
-    def notify_project_reopened(project, reopener):
+    def notify_project_reopened(project, reopener, reason_html=""):
         """
         Notify when project is reopened
 
         Args:
             project: Project instance
             reopener: User who reopened the project
+            reason_html: Optional rich text HTML reason for reopening
         """
         recipients = NotificationService._get_project_team_recipients(project)
 
@@ -1400,6 +1401,7 @@ class NotificationService:
                 "plain_project_title": strip_tags(project.title),
                 "project_url": _build_project_url(project),
                 "site_url": settings.SITE_URL,
+                "feedback_html": reason_html,
             },
         )
 

--- a/backend/documents/templates/email_templates/project_reopened_email.html
+++ b/backend/documents/templates/email_templates/project_reopened_email.html
@@ -9,6 +9,22 @@
 <p style="font-size: 14px; line-height: 26px; margin: 16px 0; color: #4b5563;">
   {% if actioning_user_name %}<strong style="color: #1f2937;">{{ actioning_user_name }}</strong> (<a href="mailto:{{ actioning_user_email }}" style="color: #2563eb; text-decoration: none; font-weight: 500;" target="_blank">{{ actioning_user_email }}</a>) has reopened {% endif %}the project{% if plain_project_title %} <strong style="color: #1f2937;">&#x27;{{ plain_project_title }}&#x27;</strong>{% endif %} that you are a member of.
 </p>
+
+{% if feedback_html %}
+<table align="center" width="100%" border="0" cellPadding="0" cellSpacing="0" role="presentation" style="margin-top:24px;margin-bottom:24px;border:1px solid #e5e7eb;border-radius:0.25rem;overflow:hidden">
+  <tbody>
+    <tr>
+      <td style="padding:16px 24px;background-color:#f9fafb">
+        <h2 style="color:#1f2937;font-size:16px;font-weight:600;margin-top:0;margin-bottom:8px">Reason for reopening:</h2>
+        <div style="font-size:14px;line-height:24px;color:#4b5563">
+          {{ feedback_html|safe }}
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+{% endif %}
+
 <p style="font-size: 14px; line-height: 26px; margin: 16px 0; color: #4b5563;">
   This project is now active again. Please review any outstanding tasks or documents.
 </p>

--- a/backend/documents/tests/test_send_email_flag.py
+++ b/backend/documents/tests/test_send_email_flag.py
@@ -1,0 +1,267 @@
+"""
+Tests for send_email flag in approval views.
+
+Verifies that:
+- When send_email=false is sent in the request, notifications are suppressed
+- When send_email is absent or true, notifications are sent as normal (backwards compatible)
+"""
+
+from unittest.mock import patch
+
+import pytest
+from rest_framework.test import APIClient
+
+from common.tests.factories import (
+    BusinessAreaFactory,
+    DivisionFactory,
+    ProjectFactory,
+    UserFactory,
+)
+from documents.models import ProjectDocument
+from documents.tests.factories import ProjectDocumentFactory
+
+
+@pytest.fixture
+def send_email_setup(db):
+    """Setup for send_email tests: superuser, project with document at various stages."""
+    superuser = UserFactory(username="admin_user", is_superuser=True)
+    ba_lead = UserFactory(username="ba_lead")
+    project_lead = UserFactory(username="project_lead")
+    division = DivisionFactory(director=superuser)
+    business_area = BusinessAreaFactory(leader=ba_lead, division=division)
+    project = ProjectFactory(business_area=business_area, kind="science")
+    project.members.create(user=project_lead, is_leader=True, role="supervising")
+    return {
+        "superuser": superuser,
+        "ba_lead": ba_lead,
+        "project_lead": project_lead,
+        "project": project,
+    }
+
+
+class TestDocApprovalSendEmail:
+    """DocApproval view respects send_email flag."""
+
+    @pytest.mark.integration
+    @patch("documents.services.approval_service.NotificationService")
+    def test_approve_with_send_email_false_suppresses_notifications(
+        self, mock_notification_service, send_email_setup
+    ):
+        """When send_email=false, no notification emails should be sent."""
+        setup = send_email_setup
+        doc = ProjectDocumentFactory(
+            project=setup["project"],
+            kind="concept",
+            status=ProjectDocument.StatusChoices.INAPPROVAL,
+            project_lead_approval_granted=False,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=setup["superuser"])
+
+        response = client.post(
+            "/api/v1/documents/actions/approve",
+            data={
+                "stage": 1,
+                "documentPk": doc.pk,
+                "send_email": False,
+            },
+            format="json",
+        )
+
+        assert response.status_code == 202
+        # Notification should NOT have been called
+        mock_notification_service.notify_document_approved.assert_not_called()
+
+    @pytest.mark.integration
+    @patch("documents.services.approval_service.NotificationService")
+    def test_approve_with_send_email_true_sends_notifications(
+        self, mock_notification_service, send_email_setup
+    ):
+        """When send_email=true (or absent), notifications should be sent as normal."""
+        setup = send_email_setup
+        doc = ProjectDocumentFactory(
+            project=setup["project"],
+            kind="concept",
+            status=ProjectDocument.StatusChoices.INAPPROVAL,
+            project_lead_approval_granted=False,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=setup["superuser"])
+
+        response = client.post(
+            "/api/v1/documents/actions/approve",
+            data={
+                "stage": 1,
+                "documentPk": doc.pk,
+                "send_email": True,
+            },
+            format="json",
+        )
+
+        assert response.status_code == 202
+        # Notification SHOULD have been called
+        mock_notification_service.notify_document_approved.assert_called_once()
+
+    @pytest.mark.integration
+    @patch("documents.services.approval_service.NotificationService")
+    def test_approve_without_send_email_field_sends_notifications(
+        self, mock_notification_service, send_email_setup
+    ):
+        """When send_email is absent from request, default to sending notifications."""
+        setup = send_email_setup
+        doc = ProjectDocumentFactory(
+            project=setup["project"],
+            kind="concept",
+            status=ProjectDocument.StatusChoices.INAPPROVAL,
+            project_lead_approval_granted=False,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=setup["superuser"])
+
+        response = client.post(
+            "/api/v1/documents/actions/approve",
+            data={
+                "stage": 1,
+                "documentPk": doc.pk,
+            },
+            format="json",
+        )
+
+        assert response.status_code == 202
+        # Notification SHOULD have been called (backwards compatible default)
+        mock_notification_service.notify_document_approved.assert_called_once()
+
+
+class TestDocRecallSendEmail:
+    """DocRecall view respects send_email flag."""
+
+    @pytest.mark.integration
+    @patch("documents.services.approval_service.NotificationService")
+    def test_recall_with_send_email_false_suppresses_notifications(
+        self, mock_notification_service, send_email_setup
+    ):
+        """When send_email=false, recall should not send notification emails."""
+        setup = send_email_setup
+        doc = ProjectDocumentFactory(
+            project=setup["project"],
+            kind="concept",
+            status=ProjectDocument.StatusChoices.INAPPROVAL,
+            project_lead_approval_granted=True,
+            business_area_lead_approval_granted=False,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=setup["superuser"])
+
+        response = client.post(
+            "/api/v1/documents/actions/recall",
+            data={
+                "stage": 1,
+                "documentPk": doc.pk,
+                "send_email": False,
+            },
+            format="json",
+        )
+
+        assert response.status_code == 202
+        mock_notification_service.notify_document_recalled.assert_not_called()
+
+    @pytest.mark.integration
+    @patch("documents.services.approval_service.NotificationService")
+    def test_recall_with_send_email_true_sends_notifications(
+        self, mock_notification_service, send_email_setup
+    ):
+        """When send_email=true, recall should send notification emails."""
+        setup = send_email_setup
+        doc = ProjectDocumentFactory(
+            project=setup["project"],
+            kind="concept",
+            status=ProjectDocument.StatusChoices.INAPPROVAL,
+            project_lead_approval_granted=True,
+            business_area_lead_approval_granted=False,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=setup["superuser"])
+
+        response = client.post(
+            "/api/v1/documents/actions/recall",
+            data={
+                "stage": 1,
+                "documentPk": doc.pk,
+                "send_email": True,
+            },
+            format="json",
+        )
+
+        assert response.status_code == 202
+        mock_notification_service.notify_document_recalled.assert_called_once()
+
+
+class TestDocSendBackSendEmail:
+    """DocSendBack view respects send_email flag."""
+
+    @pytest.mark.integration
+    @patch("documents.services.approval_service.NotificationService")
+    def test_send_back_with_send_email_false_suppresses_notifications(
+        self, mock_notification_service, send_email_setup
+    ):
+        """When send_email=false, send_back should not send notification emails."""
+        setup = send_email_setup
+        doc = ProjectDocumentFactory(
+            project=setup["project"],
+            kind="concept",
+            status=ProjectDocument.StatusChoices.INAPPROVAL,
+            project_lead_approval_granted=True,
+            business_area_lead_approval_granted=False,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=setup["superuser"])
+
+        response = client.post(
+            "/api/v1/documents/actions/send_back",
+            data={
+                "stage": 2,
+                "documentPk": doc.pk,
+                "send_email": False,
+            },
+            format="json",
+        )
+
+        assert response.status_code == 202
+        mock_notification_service.notify_document_sent_back.assert_not_called()
+
+    @pytest.mark.integration
+    @patch("documents.services.approval_service.NotificationService")
+    def test_send_back_with_send_email_true_sends_notifications(
+        self, mock_notification_service, send_email_setup
+    ):
+        """When send_email=true, send_back should send notification emails."""
+        setup = send_email_setup
+        doc = ProjectDocumentFactory(
+            project=setup["project"],
+            kind="concept",
+            status=ProjectDocument.StatusChoices.INAPPROVAL,
+            project_lead_approval_granted=True,
+            business_area_lead_approval_granted=False,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=setup["superuser"])
+
+        response = client.post(
+            "/api/v1/documents/actions/send_back",
+            data={
+                "stage": 2,
+                "documentPk": doc.pk,
+                "send_email": True,
+            },
+            format="json",
+        )
+
+        assert response.status_code == 202
+        mock_notification_service.notify_document_sent_back.assert_called_once()

--- a/backend/documents/tests/test_views_permissions.py
+++ b/backend/documents/tests/test_views_permissions.py
@@ -1435,7 +1435,9 @@ class TestDocApproval:
 
         # Assert
         assert response.status_code == status.HTTP_202_ACCEPTED
-        mock_approve.assert_called_once_with(project_document, user, feedback_html="")
+        mock_approve.assert_called_once_with(
+            project_document, user, feedback_html="", send_notifications=True
+        )
         assert "id" in response.data
 
     @patch("documents.services.approval_service.ApprovalService.approve_stage_two")
@@ -1458,7 +1460,9 @@ class TestDocApproval:
 
         # Assert
         assert response.status_code == status.HTTP_202_ACCEPTED
-        mock_approve.assert_called_once_with(project_document, user, feedback_html="")
+        mock_approve.assert_called_once_with(
+            project_document, user, feedback_html="", send_notifications=True
+        )
 
     @patch("documents.services.approval_service.ApprovalService.approve_stage_three")
     @patch("documents.services.document_service.DocumentService.get_document")
@@ -1480,7 +1484,9 @@ class TestDocApproval:
 
         # Assert
         assert response.status_code == status.HTTP_202_ACCEPTED
-        mock_approve.assert_called_once_with(project_document, user, feedback_html="")
+        mock_approve.assert_called_once_with(
+            project_document, user, feedback_html="", send_notifications=True
+        )
 
     @pytest.mark.integration
     def test_doc_approval_missing_stage(self, api_client, user, project_document, db):
@@ -1594,7 +1600,11 @@ class TestDocRecall:
         # Assert
         assert response.status_code == status.HTTP_202_ACCEPTED
         mock_recall.assert_called_once_with(
-            project_document, user, "Need to make changes", stage=2
+            project_document,
+            user,
+            "Need to make changes",
+            stage=2,
+            send_notifications=True,
         )
         assert "id" in response.data
 
@@ -1618,7 +1628,9 @@ class TestDocRecall:
 
         # Assert
         assert response.status_code == status.HTTP_202_ACCEPTED
-        mock_recall.assert_called_once_with(project_document, user, "", stage=1)
+        mock_recall.assert_called_once_with(
+            project_document, user, "", stage=1, send_notifications=True
+        )
 
     @pytest.mark.integration
     def test_doc_recall_missing_stage(self, api_client, user, project_document, db):
@@ -1698,7 +1710,7 @@ class TestDocSendBack:
         # Assert
         assert response.status_code == status.HTTP_202_ACCEPTED
         mock_send_back.assert_called_once_with(
-            project_document, user, "Needs more detail"
+            project_document, user, "Needs more detail", send_notifications=True
         )
         assert "id" in response.data
 
@@ -1722,7 +1734,9 @@ class TestDocSendBack:
 
         # Assert
         assert response.status_code == status.HTTP_202_ACCEPTED
-        mock_send_back.assert_called_once_with(project_document, user, "")
+        mock_send_back.assert_called_once_with(
+            project_document, user, "", send_notifications=True
+        )
 
     @pytest.mark.integration
     def test_doc_send_back_missing_stage(self, api_client, user, project_document, db):

--- a/backend/documents/views/admin.py
+++ b/backend/documents/views/admin.py
@@ -572,8 +572,11 @@ class ReopenProject(APIView):
                 settings.LOGGER.info(msg="Sending project reopened email")
 
                 if project:
+                    # Extract reason from request data (rich text HTML)
+                    reason_html = request.data.get("reason", "")
+
                     NotificationService.notify_project_reopened(
-                        project=project, reopener=request.user
+                        project=project, reopener=request.user, reason_html=reason_html
                     )
 
                     return Response(

--- a/backend/documents/views/approval.py
+++ b/backend/documents/views/approval.py
@@ -56,18 +56,30 @@ class DocApproval(APIView):
         # Sanitise feedback (returns "" if empty/meaningless content)
         feedback_html = sanitise_feedback_html(feedback_html)
 
+        # Read send_email preference (defaults to True for backwards compatibility)
+        send_email = request.data.get("send_email", True)
+
         # Delegate to service based on stage
         if stage == 1:
             ApprovalService.approve_stage_one(
-                document, request.user, feedback_html=feedback_html
+                document,
+                request.user,
+                feedback_html=feedback_html,
+                send_notifications=send_email,
             )
         elif stage == 2:
             ApprovalService.approve_stage_two(
-                document, request.user, feedback_html=feedback_html
+                document,
+                request.user,
+                feedback_html=feedback_html,
+                send_notifications=send_email,
             )
         elif stage == 3:
             ApprovalService.approve_stage_three(
-                document, request.user, feedback_html=feedback_html
+                document,
+                request.user,
+                feedback_html=feedback_html,
+                send_notifications=send_email,
             )
         else:
             return Response(
@@ -108,8 +120,17 @@ class DocRecall(APIView):
         # Get document
         document = DocumentService.get_document(document_pk)
 
+        # Read send_email preference (defaults to True for backwards compatibility)
+        send_email = request.data.get("send_email", True)
+
         # Delegate to service — pass stage so recall goes back exactly one step
-        ApprovalService.recall(document, request.user, feedback_html, stage=int(stage))
+        ApprovalService.recall(
+            document,
+            request.user,
+            feedback_html,
+            stage=int(stage),
+            send_notifications=send_email,
+        )
 
         # Serialize and return
         serializer = ProjectDocumentSerializer(document)
@@ -145,8 +166,13 @@ class DocSendBack(APIView):
         # Get document
         document = DocumentService.get_document(document_pk)
 
+        # Read send_email preference (defaults to True for backwards compatibility)
+        send_email = request.data.get("send_email", True)
+
         # Delegate to service
-        ApprovalService.send_back(document, request.user, feedback_html)
+        ApprovalService.send_back(
+            document, request.user, feedback_html, send_notifications=send_email
+        )
 
         # Serialize and return
         serializer = ProjectDocumentSerializer(document)

--- a/frontend/src/features/projects/components/modals/ReopenProjectModal.test.tsx
+++ b/frontend/src/features/projects/components/modals/ReopenProjectModal.test.tsx
@@ -41,6 +41,30 @@ vi.mock("@/shared/components/editor/FormRichTextEditor", () => ({
 	),
 }));
 
+// Mock the Checkbox to avoid Radix internals in tests
+vi.mock("@/shared/components/ui/checkbox", () => ({
+	Checkbox: ({
+		checked,
+		onCheckedChange,
+		id,
+		"aria-label": ariaLabel,
+	}: {
+		checked?: boolean;
+		onCheckedChange?: (checked: boolean) => void;
+		id?: string;
+		"aria-label"?: string;
+	}) => (
+		<input
+			type="checkbox"
+			role="checkbox"
+			id={id}
+			checked={checked}
+			onChange={(e) => onCheckedChange?.(e.target.checked)}
+			aria-label={ariaLabel}
+		/>
+	),
+}));
+
 describe("ReopenProjectModal", () => {
 	const defaultProps = {
 		isOpen: true,
@@ -56,7 +80,6 @@ describe("ReopenProjectModal", () => {
 	});
 
 	it("enables submit button when checkbox is ticked and reason has 10+ characters", async () => {
-		const user = userEvent.setup();
 		render(<ReopenProjectModal {...defaultProps} />);
 
 		// Tick the checkbox
@@ -67,15 +90,20 @@ describe("ReopenProjectModal", () => {
 
 		// Enter a reason with 10+ characters in the rich text editor
 		const editor = screen.getByTestId("rich-text-editor");
-		await user.type(editor, "Need to fix progress report");
+		fireEvent.change(editor, {
+			target: { value: "Need to fix progress report" },
+		});
 
 		// Button should now be enabled
-		await waitFor(() => {
-			const submitButton = screen.getByRole("button", {
-				name: /open project/i,
-			});
-			expect(submitButton).not.toBeDisabled();
-		});
+		await waitFor(
+			() => {
+				const submitButton = screen.getByRole("button", {
+					name: /open project/i,
+				});
+				expect(submitButton).not.toBeDisabled();
+			},
+			{ timeout: 3000 }
+		);
 	});
 
 	it("keeps submit button disabled when only checkbox is ticked (no reason)", () => {
@@ -112,7 +140,6 @@ describe("ReopenProjectModal", () => {
 	});
 
 	it("disables submit button when checkbox is unticked after being ticked", async () => {
-		const user = userEvent.setup();
 		render(<ReopenProjectModal {...defaultProps} />);
 
 		// Tick the checkbox
@@ -123,26 +150,34 @@ describe("ReopenProjectModal", () => {
 
 		// Enter a valid reason
 		const editor = screen.getByTestId("rich-text-editor");
-		await user.type(editor, "Need to fix progress report");
+		fireEvent.change(editor, {
+			target: { value: "Need to fix progress report" },
+		});
 
 		// Verify button is enabled
-		await waitFor(() => {
-			const submitButton = screen.getByRole("button", {
-				name: /open project/i,
-			});
-			expect(submitButton).not.toBeDisabled();
-		});
+		await waitFor(
+			() => {
+				const submitButton = screen.getByRole("button", {
+					name: /open project/i,
+				});
+				expect(submitButton).not.toBeDisabled();
+			},
+			{ timeout: 3000 }
+		);
 
 		// Untick the checkbox
 		fireEvent.click(checkbox);
 
 		// Button should be disabled again
-		await waitFor(() => {
-			const submitButton = screen.getByRole("button", {
-				name: /open project/i,
-			});
-			expect(submitButton).toBeDisabled();
-		});
+		await waitFor(
+			() => {
+				const submitButton = screen.getByRole("button", {
+					name: /open project/i,
+				});
+				expect(submitButton).toBeDisabled();
+			},
+			{ timeout: 3000 }
+		);
 	});
 
 	it("shows reason field as disabled (greyed out) before checkbox is ticked", () => {

--- a/frontend/src/features/projects/components/modals/ReopenProjectModal.test.tsx
+++ b/frontend/src/features/projects/components/modals/ReopenProjectModal.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Tests for ReopenProjectModal — verifies the "Open Project" button
+ * enables/disables correctly based on form state.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ReopenProjectModal } from "./ReopenProjectModal";
+
+// Mock react-router
+vi.mock("react-router", () => ({
+	useNavigate: () => vi.fn(),
+}));
+
+// Mock the useReopenProject hook
+vi.mock("@/features/projects/hooks/useReopenProject", () => ({
+	useReopenProject: () => ({
+		mutate: vi.fn(),
+		isPending: false,
+	}),
+}));
+
+// Mock the FormRichTextEditor since it has complex dependencies
+vi.mock("@/shared/components/editor/FormRichTextEditor", () => ({
+	FormRichTextEditor: ({
+		value,
+		onChange,
+		placeholder,
+	}: {
+		value: string;
+		onChange: (val: string) => void;
+		placeholder?: string;
+	}) => (
+		<textarea
+			data-testid="rich-text-editor"
+			value={value}
+			onChange={(e) => onChange(e.target.value)}
+			placeholder={placeholder}
+			aria-label="Reason for reopening"
+		/>
+	),
+}));
+
+describe("ReopenProjectModal", () => {
+	const defaultProps = {
+		isOpen: true,
+		onClose: vi.fn(),
+		projectId: 123,
+	};
+
+	it("renders with submit button disabled initially", () => {
+		render(<ReopenProjectModal {...defaultProps} />);
+
+		const submitButton = screen.getByRole("button", { name: /open project/i });
+		expect(submitButton).toBeDisabled();
+	});
+
+	it("enables submit button when checkbox is ticked and reason has 10+ characters", async () => {
+		const user = userEvent.setup();
+		render(<ReopenProjectModal {...defaultProps} />);
+
+		// Tick the checkbox
+		const checkbox = screen.getByRole("checkbox", {
+			name: /are you sure you want to reopen this project/i,
+		});
+		fireEvent.click(checkbox);
+
+		// Enter a reason with 10+ characters in the rich text editor
+		const editor = screen.getByTestId("rich-text-editor");
+		await user.type(editor, "Need to fix progress report");
+
+		// Button should now be enabled
+		await waitFor(() => {
+			const submitButton = screen.getByRole("button", {
+				name: /open project/i,
+			});
+			expect(submitButton).not.toBeDisabled();
+		});
+	});
+
+	it("keeps submit button disabled when only checkbox is ticked (no reason)", () => {
+		render(<ReopenProjectModal {...defaultProps} />);
+
+		// Tick the checkbox
+		const checkbox = screen.getByRole("checkbox", {
+			name: /are you sure you want to reopen this project/i,
+		});
+		fireEvent.click(checkbox);
+
+		// Don't enter a reason — button should remain disabled
+		const submitButton = screen.getByRole("button", { name: /open project/i });
+		expect(submitButton).toBeDisabled();
+	});
+
+	it("keeps submit button disabled when reason is too short", async () => {
+		const user = userEvent.setup();
+		render(<ReopenProjectModal {...defaultProps} />);
+
+		// Tick the checkbox
+		const checkbox = screen.getByRole("checkbox", {
+			name: /are you sure you want to reopen this project/i,
+		});
+		fireEvent.click(checkbox);
+
+		// Enter a short reason (less than 10 chars)
+		const editor = screen.getByTestId("rich-text-editor");
+		await user.type(editor, "Short");
+
+		// Button should remain disabled
+		const submitButton = screen.getByRole("button", { name: /open project/i });
+		expect(submitButton).toBeDisabled();
+	});
+
+	it("disables submit button when checkbox is unticked after being ticked", async () => {
+		const user = userEvent.setup();
+		render(<ReopenProjectModal {...defaultProps} />);
+
+		// Tick the checkbox
+		const checkbox = screen.getByRole("checkbox", {
+			name: /are you sure you want to reopen this project/i,
+		});
+		fireEvent.click(checkbox);
+
+		// Enter a valid reason
+		const editor = screen.getByTestId("rich-text-editor");
+		await user.type(editor, "Need to fix progress report");
+
+		// Verify button is enabled
+		await waitFor(() => {
+			const submitButton = screen.getByRole("button", {
+				name: /open project/i,
+			});
+			expect(submitButton).not.toBeDisabled();
+		});
+
+		// Untick the checkbox
+		fireEvent.click(checkbox);
+
+		// Button should be disabled again
+		await waitFor(() => {
+			const submitButton = screen.getByRole("button", {
+				name: /open project/i,
+			});
+			expect(submitButton).toBeDisabled();
+		});
+	});
+
+	it("shows reason field as disabled (greyed out) before checkbox is ticked", () => {
+		render(<ReopenProjectModal {...defaultProps} />);
+
+		// The reason section should have opacity-50 and pointer-events-none
+		const editor = screen.getByTestId("rich-text-editor");
+		const editorContainer = editor.closest("[class*='opacity-50']");
+		expect(editorContainer).not.toBeNull();
+	});
+
+	it("shows required indicator (red star) on reason label", () => {
+		render(<ReopenProjectModal {...defaultProps} />);
+
+		const label = screen.getByText(/reason for reopening/i);
+		const star = label.querySelector(".text-destructive");
+		expect(star).not.toBeNull();
+		expect(star?.textContent).toBe("*");
+	});
+});

--- a/frontend/src/features/projects/components/modals/ReopenProjectModal.tsx
+++ b/frontend/src/features/projects/components/modals/ReopenProjectModal.tsx
@@ -1,6 +1,4 @@
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
+import { useState } from "react";
 import { useNavigate } from "react-router";
 import {
 	Dialog,
@@ -12,19 +10,9 @@ import {
 } from "@/shared/components/ui/dialog";
 import { Button } from "@/shared/components/ui/button";
 import { Checkbox } from "@/shared/components/ui/checkbox";
-import { Textarea } from "@/shared/components/ui/textarea";
 import { Label } from "@/shared/components/ui/label";
+import { FormRichTextEditor } from "@/shared/components/editor/FormRichTextEditor";
 import { useReopenProject } from "@/features/projects/hooks/useReopenProject";
-
-const reopenSchema = z.object({
-	projectId: z.number(),
-	confirmed: z.boolean().refine((val) => val === true, {
-		message: "You must confirm to reopen the project",
-	}),
-	reason: z.string().min(10, "Reason must be at least 10 characters"),
-});
-
-type ReopenFormData = z.infer<typeof reopenSchema>;
 
 interface ReopenProjectModalProps {
 	isOpen: boolean;
@@ -32,46 +20,57 @@ interface ReopenProjectModalProps {
 	projectId: number;
 }
 
+/**
+ * Minimum character length for the reason (stripped of HTML tags)
+ */
+const MIN_REASON_LENGTH = 10;
+
+/**
+ * Strip HTML tags and get plain text length
+ */
+const getPlainTextLength = (html: string): number => {
+	const text = html.replace(/<[^>]*>/g, "").trim();
+	return text.length;
+};
+
 export const ReopenProjectModal = ({
 	isOpen,
 	onClose,
 	projectId,
 }: ReopenProjectModalProps) => {
-	const {
-		register,
-		handleSubmit,
-		formState: { errors },
-		watch,
-		setValue,
-	} = useForm<ReopenFormData>({
-		resolver: zodResolver(reopenSchema),
-		defaultValues: {
-			projectId,
-			confirmed: false,
-			reason: "",
-		},
-	});
+	const [confirmed, setConfirmed] = useState(false);
+	const [reasonHTML, setReasonHTML] = useState("");
 
 	const reopenMutation = useReopenProject();
 	const navigate = useNavigate();
-	// eslint-disable-next-line react-hooks/incompatible-library
-	const confirmed = watch("confirmed");
-	const reason = watch("reason");
-	const canSubmit = confirmed && reason.length >= 10;
 
-	const onSubmit = (data: ReopenFormData) => {
-		reopenMutation.mutate(data.projectId, {
-			onSuccess: () => {
-				onClose();
-				// Navigate to the overview tab — the closure tab no longer exists
-				navigate(`/projects/${data.projectId}`);
-			},
-		});
+	const reasonLength = getPlainTextLength(reasonHTML);
+	const canSubmit = confirmed && reasonLength >= MIN_REASON_LENGTH;
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		if (!canSubmit) return;
+
+		reopenMutation.mutate(
+			{ projectId, reason: reasonHTML },
+			{
+				onSuccess: () => {
+					onClose();
+					navigate(`/projects/${projectId}`);
+				},
+			}
+		);
+	};
+
+	const handleClose = () => {
+		setConfirmed(false);
+		setReasonHTML("");
+		onClose();
 	};
 
 	return (
-		<Dialog open={isOpen} onOpenChange={onClose}>
-			<DialogContent className="sm:max-w-[500px]">
+		<Dialog open={isOpen} onOpenChange={handleClose}>
+			<DialogContent className="sm:max-w-[600px]">
 				<DialogHeader>
 					<DialogTitle>
 						Are you sure you want to reopen this project?
@@ -81,13 +80,13 @@ export const ReopenProjectModal = ({
 					</DialogDescription>
 				</DialogHeader>
 
-				<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+				<form onSubmit={handleSubmit} className="space-y-4">
 					<div className="rounded-lg bg-muted p-4">
 						<h4 className="mb-3 text-lg font-semibold">Info</h4>
 						<ul className="ml-6 list-disc space-y-2 text-sm">
 							<li>
 								The project will become active, with the status set to
-								'updating'
+								&apos;updating&apos;
 							</li>
 							<li>The project closure document will be deleted</li>
 							<li>Progress Reports can be created again</li>
@@ -102,9 +101,7 @@ export const ReopenProjectModal = ({
 						<Checkbox
 							id="confirmed"
 							checked={confirmed}
-							onCheckedChange={(checked) =>
-								setValue("confirmed", checked as boolean)
-							}
+							onCheckedChange={(checked) => setConfirmed(checked as boolean)}
 							aria-label="Are you sure you want to reopen this project?"
 						/>
 						<Label
@@ -114,31 +111,32 @@ export const ReopenProjectModal = ({
 							Are you sure you want to reopen this project?
 						</Label>
 					</div>
-					{errors.confirmed && (
-						<p className="text-sm text-destructive">
-							{errors.confirmed.message}
-						</p>
-					)}
 
-					{/* Reason Textarea */}
-					<div className="space-y-2">
-						<Label htmlFor="reason">Reason for reopening</Label>
-						<Textarea
-							id="reason"
-							{...register("reason")}
+					{/* Reason Rich Text Editor — only active after checkbox is ticked */}
+					<div
+						className={`space-y-2 ${!confirmed ? "opacity-50 pointer-events-none" : ""}`}
+					>
+						<label className="text-sm font-medium leading-none text-gray-900 dark:text-gray-100">
+							Reason for reopening <span className="text-destructive">*</span>
+						</label>
+						<FormRichTextEditor
+							value={reasonHTML}
+							onChange={setReasonHTML}
+							toolbar="simple"
 							placeholder="Please provide a reason for reopening this project..."
-							className="min-h-[100px]"
-							aria-label="Reason for reopening"
+							wordLimit={500}
 						/>
-						{errors.reason && (
-							<p className="text-sm text-destructive">
-								{errors.reason.message}
-							</p>
-						)}
+						{confirmed &&
+							reasonLength > 0 &&
+							reasonLength < MIN_REASON_LENGTH && (
+								<p className="text-sm text-destructive">
+									Reason must be at least {MIN_REASON_LENGTH} characters
+								</p>
+							)}
 					</div>
 
 					<DialogFooter className="gap-2">
-						<Button type="button" variant="outline" onClick={onClose}>
+						<Button type="button" variant="outline" onClick={handleClose}>
 							Cancel
 						</Button>
 						<Button

--- a/frontend/src/features/projects/components/modals/ReopenProjectModal.tsx
+++ b/frontend/src/features/projects/components/modals/ReopenProjectModal.tsx
@@ -26,11 +26,19 @@ interface ReopenProjectModalProps {
 const MIN_REASON_LENGTH = 10;
 
 /**
- * Strip HTML tags and get plain text length
+ * Get plain text length from HTML content.
+ * Used only for character counting (not for sanitisation).
  */
 const getPlainTextLength = (html: string): number => {
-	const text = html.replace(/<[^>]*>/g, "").trim();
-	return text.length;
+	if (!html) return 0;
+	if (typeof DOMParser !== "undefined") {
+		const doc = new DOMParser().parseFromString(html, "text/html");
+		return (doc.body.textContent || "").trim().length;
+	}
+	// Fallback for environments without DOMParser
+	const div = document.createElement("div");
+	div.innerHTML = html;
+	return (div.textContent || "").trim().length;
 };
 
 export const ReopenProjectModal = ({

--- a/frontend/src/features/projects/components/tabs/ProjectClosureTab.test.tsx
+++ b/frontend/src/features/projects/components/tabs/ProjectClosureTab.test.tsx
@@ -41,6 +41,26 @@ vi.mock("@/shared/components/editor", () => ({
 	),
 }));
 
+vi.mock("@/shared/components/editor/FormRichTextEditor", () => ({
+	FormRichTextEditor: ({
+		value,
+		onChange,
+		placeholder,
+	}: {
+		value: string;
+		onChange: (val: string) => void;
+		placeholder?: string;
+	}) => (
+		<textarea
+			data-testid="rich-text-editor"
+			value={value}
+			onChange={(e) => onChange(e.target.value)}
+			placeholder={placeholder}
+			aria-label="Reason for reopening"
+		/>
+	),
+}));
+
 vi.mock("@/shared/components/ProjectSection", () => ({
 	ProjectSection: ({
 		title,
@@ -258,20 +278,11 @@ describe("ProjectClosureTab", () => {
 		const reopenButton = screen.getByTestId("reopen-project-button");
 		await user.click(reopenButton);
 
-		// Reason textarea should exist in the modal
+		// Rich text editor for reason should exist in the modal
 		await waitFor(() => {
-			const textarea = screen.queryByRole("textbox", {
-				name: /reason/i,
-			});
-			expect(textarea).toBeInTheDocument();
+			const editor = screen.queryByTestId("rich-text-editor");
+			expect(editor).toBeInTheDocument();
 		});
-
-		const textarea = screen.queryByRole("textbox");
-		if (textarea) {
-			console.log("Reason textarea found — modal is implemented");
-		} else {
-			console.log("Reason textarea not found — modal may not be implemented");
-		}
 	});
 
 	/**

--- a/frontend/src/features/projects/hooks/useReopenProject.ts
+++ b/frontend/src/features/projects/hooks/useReopenProject.ts
@@ -3,18 +3,30 @@ import { apiClient } from "@/shared/services/api/client.service";
 import { toast } from "sonner";
 import { extractUserFriendlyMessage } from "@/shared/utils/error.utils";
 
+interface ReopenProjectParams {
+	projectId: number;
+	reason?: string;
+}
+
 /**
  * Reopen a closed project by deleting the project closure document
  */
-const reopenProject = async (projectId: number): Promise<void> => {
+const reopenProject = async ({
+	projectId,
+	reason,
+}: ReopenProjectParams): Promise<void> => {
 	const url = `documents/projectclosures/reopen/${projectId}`;
-	return apiClient.post<void>(url, { project: projectId });
+	return apiClient.post<void>(url, {
+		project: projectId,
+		reason: reason || "",
+	});
 };
 
 /**
  * Hook for reopening a closed project
  * - Deletes the project closure document
  * - Sets project status to 'updating'
+ * - Sends reason for reopening in the notification email
  * - Invalidates project queries on success
  * - Shows success/error toast notifications
  *
@@ -24,10 +36,12 @@ export const useReopenProject = () => {
 	const queryClient = useQueryClient();
 
 	return useMutation({
-		mutationFn: (projectId: number) => reopenProject(projectId),
-		onSuccess: (_data, projectId) => {
+		mutationFn: (params: ReopenProjectParams) => reopenProject(params),
+		onSuccess: (_data, params) => {
 			// Invalidate project queries to refetch updated project
-			queryClient.invalidateQueries({ queryKey: ["projects", projectId] });
+			queryClient.invalidateQueries({
+				queryKey: ["projects", params.projectId],
+			});
 			queryClient.invalidateQueries({ queryKey: ["projects"] });
 
 			// Show success toast

--- a/frontend/src/shared/components/documents/DocumentActionsSection.tsx
+++ b/frontend/src/shared/components/documents/DocumentActionsSection.tsx
@@ -167,12 +167,9 @@ export const DocumentActionsSection = ({
 
 	// Delete button: Show when project lead approval NOT granted AND document NOT directorate approved
 	// Special case: project plans with no progress reports can be deleted even if partially approved
+	// Special case: progress/student reports on closed projects can be deleted by authorised users
+	// Lifecycle protection: can't delete if a later-stage document exists
 	const canDelete = useMemo(() => {
-		// Never show if fully approved
-		if (document.directorate_approval_granted) {
-			return false;
-		}
-
 		// Check if user has permission (project lead, superuser, or caretaker)
 		const hasPermission =
 			currentUser?.is_superuser ||
@@ -183,6 +180,41 @@ export const DocumentActionsSection = ({
 			userIsCaretakerOfBaLeader;
 
 		if (!hasPermission) return false;
+
+		// Lifecycle protection: can't delete if a later-stage document exists
+		if (documentType === "concept") {
+			// Can't delete concept plan if project plan exists
+			if (all_documents?.project_plan) return false;
+		}
+		if (documentType === "projectplan") {
+			// Can't delete project plan if progress reports or student reports exist
+			if (
+				all_documents?.progress_reports &&
+				all_documents.progress_reports.length > 0
+			)
+				return false;
+			if (
+				all_documents?.student_reports &&
+				all_documents.student_reports.length > 0
+			)
+				return false;
+		}
+
+		// Closed-project exemption: progress/student reports can be deleted by authorised users
+		// regardless of approval state when the project is completed or terminated
+		const isClosedProject =
+			project.status === "completed" || project.status === "terminated";
+		const isExemptDocType =
+			documentType === "progressreport" || documentType === "studentreport";
+
+		if (isClosedProject && isExemptDocType) {
+			return true;
+		}
+
+		// Never show if fully approved (standard rule for non-exempt cases)
+		if (document.directorate_approval_granted) {
+			return false;
+		}
 
 		// Show for new documents (project lead approval not granted)
 		if (!document.project_lead_approval_granted) {
@@ -204,6 +236,7 @@ export const DocumentActionsSection = ({
 		document,
 		documentType,
 		all_documents,
+		project.status,
 		isProjectLead,
 		isBaLead,
 		userIsCaretakerOfAdmin,
@@ -451,6 +484,24 @@ export const DocumentActionsSection = ({
 							</p>
 						</div>
 					)}
+
+					{/* Delete button for exempt documents on closed projects (outside the overlay) */}
+					{isProtected && canDelete && onDelete && (
+						<div className="rounded-lg border-2 border-red-200 dark:border-red-800 bg-red-50/50 dark:bg-red-950/20 p-3 space-y-2">
+							<h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+								Delete Document
+							</h3>
+							<Button
+								onClick={onDelete}
+								variant="action-red"
+								size="sm"
+								className="w-full"
+							>
+								<Trash2 className="mr-2 h-4 w-4" aria-hidden="true" />
+								Delete Document
+							</Button>
+						</div>
+					)}
 					{/* Approval Status Section with actions under each stage */}
 					<div
 						className={`rounded-lg border-2 border-gray-300 dark:border-gray-600 bg-muted/30 dark:bg-gray-900 p-3 space-y-3 ${locked || isProtected ? "opacity-50 pointer-events-none" : ""}`}
@@ -476,8 +527,8 @@ export const DocumentActionsSection = ({
 											Submit for Approval
 										</Button>
 									)}
-									{/* Delete button - Red (only when project lead approval NOT granted) */}
-									{canDelete && onDelete && (
+									{/* Delete button - Red (only when not protected — protected case uses the exempt section above) */}
+									{canDelete && !isProtected && onDelete && (
 										<Button
 											onClick={onDelete}
 											variant="action-red"

--- a/frontend/src/shared/components/documents/UnifiedDocumentActionModal.tsx
+++ b/frontend/src/shared/components/documents/UnifiedDocumentActionModal.tsx
@@ -321,7 +321,9 @@ export const UnifiedDocumentActionModal = ({
 		}
 
 		onSubmit(formData);
-		reset();
+		// Do NOT reset here — the modal stays open for the success animation.
+		// Resetting immediately re-ticks the email checkbox (default: true) which
+		// confuses the user. The form is reset when the modal closes via handleClose.
 		setFeedbackHTML("");
 	};
 

--- a/frontend/src/shared/services/document.service.test.ts
+++ b/frontend/src/shared/services/document.service.test.ts
@@ -25,7 +25,7 @@ describe("performDocumentAction", () => {
 		(apiClient.post as Mock).mockResolvedValue({});
 	});
 
-	it("approve action sends stage, documentPk, and feedbackHTML", async () => {
+	it("approve action sends stage, documentPk, feedbackHTML, and send_email", async () => {
 		await performDocumentAction("concept", 42, {
 			action: "approve",
 			stage: 2,
@@ -40,6 +40,7 @@ describe("performDocumentAction", () => {
 				stage: 2,
 				documentPk: 42,
 				feedbackHTML: "<p>Looks good</p>",
+				send_email: true,
 			})
 		);
 	});
@@ -84,7 +85,19 @@ describe("performDocumentAction", () => {
 		);
 	});
 
-	it("does NOT send send_email field to backend", async () => {
+	it("includes send_email field in POST body", async () => {
+		await performDocumentAction("concept", 42, {
+			action: "approve",
+			stage: 1,
+			documentPk: 42,
+			send_email: false,
+		});
+
+		const payload = (apiClient.post as Mock).mock.calls[0][1];
+		expect(payload).toHaveProperty("send_email", false);
+	});
+
+	it("includes send_email=true when checkbox is selected", async () => {
 		await performDocumentAction("concept", 42, {
 			action: "approve",
 			stage: 1,
@@ -93,7 +106,7 @@ describe("performDocumentAction", () => {
 		});
 
 		const payload = (apiClient.post as Mock).mock.calls[0][1];
-		expect(payload).not.toHaveProperty("send_email");
+		expect(payload).toHaveProperty("send_email", true);
 	});
 
 	it("throws for unknown action", async () => {

--- a/frontend/src/shared/services/document.service.ts
+++ b/frontend/src/shared/services/document.service.ts
@@ -44,6 +44,7 @@ export const performDocumentAction = async (
 		documentPk: documentId,
 		reason: data.reason,
 		feedbackHTML: data.feedbackHTML,
+		send_email: data.send_email,
 	});
 };
 


### PR DESCRIPTION
- Allow deletion of progress/student reports on closed projects for authorised users (admins, project leads, BA leads, caretakers)
- Add lifecycle protection preventing deletion of documents when later-stage documents exist (concept if plan exists, plan if reports exist)
- Render delete button outside the protection overlay for exempt documents
- Fix email checkbox being ignored during approval actions by passing send_email through to backend and removing premature form reset
- Backend views now read send_email and pass send_notifications to services
- Fix reopen modal button staying disabled by using formState.isValid
- Replace plain textarea with rich text editor in reopen modal
- Include reopening reason in the project reopened notification email
- Make reason field required with red star, only active after confirmation