### PR TITLE
chore, ref: add additional ref for auth/csrf per env

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -191,7 +191,36 @@ if DEBUG:
 else:
     CSRF_TRUSTED_ORIGINS = [f"https://{domain}" for domain in CURRENT_DOMAINS.values()]
 
-CSRF_COOKIE_NAME = "spmscsrf"  # Set custom CSRF cookie name
+# Cookie names are set per environment. Staging and production both live under
+# the shared parent cookie domain (.dbca.wa.gov.au), so they now use different
+# names; otherwise a user who visits both would have one environment's cookies
+# overwrite the other's. Production keeps the historical names so existing
+# sessions aren't disrupted; other environments use a distinct prefix.
+# Development runs on a separate host (127.0.0.1) and can't collide, but is
+# named distinctly for consistency.
+# NOTE: Though we have not encountered any real issues with the previous approach, the session-name prefix/split is a good direction.
+# It stops staging and production sessions between apps from overwriting each other.
+# The CSRF split is additional hardening;
+# a shared CSRF cookie was already safe, because Django validates the submitted
+# token against the cookie value. Production is unaffected; staging and
+# development need a one-time re-login because their cookie names changed.
+#
+# Only the cookie NAMES change in this block. The CSRF header name
+# (X-CSRFToken) is unchanged, so the frontend submits the token identically
+# everywhere; it just reads it from the environment-specific cookie.
+CSRF_COOKIE_NAMES = {
+    "development": "spms_dev_csrf",
+    "staging": "spms_test_csrf",
+    "production": "spmscsrf",
+}
+CSRF_COOKIE_NAME = CSRF_COOKIE_NAMES.get(ENVIRONMENT, "spmscsrf")
+
+SESSION_COOKIE_NAMES = {
+    "development": "spms_dev_sessionid",
+    "staging": "spms_test_sessionid",
+    "production": "spms_sessionid",
+}
+SESSION_COOKIE_NAME = SESSION_COOKIE_NAMES.get(ENVIRONMENT, "spms_sessionid")
 
 CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOW_METHODS = [
@@ -220,8 +249,7 @@ if DEBUG:
 
 
 if not DEBUG:
-    # Secure cookie configuration for production
-    SESSION_COOKIE_NAME = "spms_sessionid"
+    # Secure cookie configuration for staging and production
     SESSION_COOKIE_DOMAIN = ".dbca.wa.gov.au"
     CSRF_COOKIE_DOMAIN = ".dbca.wa.gov.au"
 

--- a/backend/users/tests/test_views.py
+++ b/backend/users/tests/test_views.py
@@ -57,6 +57,7 @@ class TestAuthenticationViews:
         response = api_client.post(users_urls.path("log-in"), data, format="json")
 
         # Assert
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "error" in response.data
 
     def test_logout_authenticated(self, api_client, user):

--- a/backend/users/views/auth.py
+++ b/backend/users/views/auth.py
@@ -9,7 +9,7 @@ from django.views.decorators.csrf import csrf_exempt
 from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.status import HTTP_200_OK
+from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from rest_framework.views import APIView
 
 from users.services import UserService
@@ -41,7 +41,9 @@ class Login(APIView):
             UserService.login_user(request, user)
             return Response({"ok": "Welcome"})
         else:
-            return Response({"error": "Incorrect password"})
+            return Response(
+                {"error": "Incorrect password"}, status=HTTP_400_BAD_REQUEST
+            )
 
 
 class Logout(APIView):

--- a/frontend/src/app/stores/derived/auth.store.test.ts
+++ b/frontend/src/app/stores/derived/auth.store.test.ts
@@ -3,6 +3,7 @@ import { AuthStore } from "./auth.store";
 import { getSSOMe } from "@/features/auth/services/auth.service";
 import Cookie from "js-cookie";
 import { logger } from "@/shared/services/logger.service";
+import { getCsrfCookieName } from "@/shared/constants";
 import type { IUserMe } from "@/shared/types/user.types";
 
 vi.mock("@/features/auth/services/auth.service");
@@ -98,8 +99,7 @@ describe("AuthStore.initialise", () => {
 			expect(authStore.isAuthenticated).toBe(false);
 			expect(authStore.user).toBe(null);
 			expect(authStore.state.initialised).toBe(true);
-			expect(mockCookieRemove).toHaveBeenCalledWith("sessionid");
-			expect(mockCookieRemove).toHaveBeenCalledWith("spmscsrf");
+			expect(mockCookieRemove).toHaveBeenCalledWith(getCsrfCookieName());
 			expect(mockCookieRemove).toHaveBeenCalledWith("csrf");
 			expect(logger.warn).toHaveBeenCalledWith(
 				"Session invalid - clearing auth state",
@@ -124,8 +124,7 @@ describe("AuthStore.initialise", () => {
 			expect(authStore.isAuthenticated).toBe(false);
 			expect(authStore.user).toBe(null);
 			expect(authStore.state.initialised).toBe(true);
-			expect(mockCookieRemove).toHaveBeenCalledWith("sessionid");
-			expect(mockCookieRemove).toHaveBeenCalledWith("spmscsrf");
+			expect(mockCookieRemove).toHaveBeenCalledWith(getCsrfCookieName());
 			expect(mockCookieRemove).toHaveBeenCalledWith("csrf");
 			expect(logger.warn).toHaveBeenCalledWith(
 				"Session invalid - clearing auth state",
@@ -334,8 +333,7 @@ describe("AuthStore other methods", () => {
 
 			expect(authStore.isAuthenticated).toBe(false);
 			expect(authStore.user).toBe(null);
-			expect(mockCookieRemove).toHaveBeenCalledWith("sessionid");
-			expect(mockCookieRemove).toHaveBeenCalledWith("spmscsrf");
+			expect(mockCookieRemove).toHaveBeenCalledWith(getCsrfCookieName());
 			expect(mockCookieRemove).toHaveBeenCalledWith("csrf");
 		});
 	});

--- a/frontend/src/app/stores/derived/auth.store.ts
+++ b/frontend/src/app/stores/derived/auth.store.ts
@@ -5,6 +5,7 @@ import { makeObservable, observable, computed, action } from "mobx";
 import Cookie from "js-cookie";
 import { getSSOMe } from "@/features/auth/services/auth.service";
 import type { ApiError } from "@/shared/services/api/client.service";
+import { AUTH_COOKIES, getCsrfCookieName } from "@/shared/constants";
 
 interface AuthStoreState extends BaseStoreState {
 	isAuthenticated: boolean;
@@ -62,7 +63,7 @@ export class AuthStore extends BaseStore<AuthStoreState> {
 	 */
 	setUser(user: IUserMe | null) {
 		this.user = user;
-		const hasCsrf = !!Cookie.get("spmscsrf");
+		const hasCsrf = !!Cookie.get(getCsrfCookieName());
 		this.state.isAuthenticated = !!user || hasCsrf;
 	}
 
@@ -89,7 +90,7 @@ export class AuthStore extends BaseStore<AuthStoreState> {
 	 * then validate with the backend to confirm.
 	 */
 	async initialise() {
-		const hasCsrf = !!Cookie.get("spmscsrf");
+		const hasCsrf = !!Cookie.get(getCsrfCookieName());
 
 		logger.info("Auth store initialising", {
 			hasCsrf,
@@ -165,9 +166,10 @@ export class AuthStore extends BaseStore<AuthStoreState> {
 	logout() {
 		this.state.isAuthenticated = false;
 		this.user = null;
-		Cookie.remove("sessionid");
-		Cookie.remove("spmscsrf");
-		Cookie.remove("csrf");
+		// Only the readable CSRF cookies can be cleared here. The session
+		// cookie is HttpOnly and is expired by the backend on logout.
+		Cookie.remove(getCsrfCookieName());
+		Cookie.remove(AUTH_COOKIES.LEGACY_CSRF);
 		logger.info("User logged out");
 	}
 

--- a/frontend/src/features/auth/services/auth.service.ts
+++ b/frontend/src/features/auth/services/auth.service.ts
@@ -2,9 +2,15 @@ import type {
 	LoginFormData,
 	IUsernameLoginSuccess,
 } from "@/features/auth/types";
-import { apiClient } from "@/shared/services/api/client.service";
+import { apiClient, type ApiError } from "@/shared/services/api/client.service";
 import { AUTH_ENDPOINTS } from "./auth.endpoints";
 import type { IUserMe } from "@/shared/types/user.types";
+
+const INVALID_CREDENTIALS_MESSAGE =
+	"Please check your credentials and try again.";
+
+const isApiError = (error: unknown): error is ApiError =>
+	typeof error === "object" && error !== null && "status" in error;
 
 /**
  * Login with username and password.
@@ -17,13 +23,24 @@ export const logInOrdinary = async ({
 	// Ensure a CSRF cookie exists before POSTing
 	await apiClient.get(AUTH_ENDPOINTS.LOGIN);
 
-	const response = await apiClient.post<IUsernameLoginSuccess>(
-		AUTH_ENDPOINTS.LOGIN,
-		{ username, password }
-	);
+	let response: IUsernameLoginSuccess;
+	try {
+		response = await apiClient.post<IUsernameLoginSuccess>(
+			AUTH_ENDPOINTS.LOGIN,
+			{ username, password }
+		);
+	} catch (error) {
+		// The API returns 400 for invalid credentials. Surface a single,
+		// non-revealing message; network and server errors propagate unchanged.
+		if (isApiError(error) && error.status === 400) {
+			throw new Error(INVALID_CREDENTIALS_MESSAGE, { cause: error });
+		}
+		throw error;
+	}
 
+	// Defensive: a 2xx response should always carry `ok`.
 	if (!response.ok) {
-		throw new Error("Please check your credentials and try again.");
+		throw new Error(INVALID_CREDENTIALS_MESSAGE);
 	}
 
 	return response;

--- a/frontend/src/shared/constants/auth.test.ts
+++ b/frontend/src/shared/constants/auth.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getCsrfCookieName } from "./auth";
+
+/**
+ * getCsrfCookieName resolves the CSRF cookie name from the current host.
+ * A single bundle serves every environment, so the staging and production
+ * hosts (which share the .dbca.wa.gov.au parent domain) must be told apart at
+ * runtime — staging first, since staging hosts also end with .dbca.wa.gov.au.
+ */
+
+const originalLocation = window.location;
+
+const setHostname = (hostname: string) => {
+	Object.defineProperty(window, "location", {
+		configurable: true,
+		value: { ...originalLocation, hostname },
+	});
+};
+
+afterEach(() => {
+	Object.defineProperty(window, "location", {
+		configurable: true,
+		value: originalLocation,
+	});
+});
+
+describe("getCsrfCookieName", () => {
+	it("returns the staging name on the staging app host", () => {
+		setHostname("scienceprojects-test.dbca.wa.gov.au");
+		expect(getCsrfCookieName()).toBe("spms_test_csrf");
+	});
+
+	it("returns the staging name on the staging profiles host", () => {
+		setHostname("science-profiles-test.dbca.wa.gov.au");
+		expect(getCsrfCookieName()).toBe("spms_test_csrf");
+	});
+
+	it("returns the production name on the production app host", () => {
+		setHostname("scienceprojects.dbca.wa.gov.au");
+		expect(getCsrfCookieName()).toBe("spmscsrf");
+	});
+
+	it("returns the production name on the production profiles host", () => {
+		setHostname("science-profiles.dbca.wa.gov.au");
+		expect(getCsrfCookieName()).toBe("spmscsrf");
+	});
+
+	it("returns the development name on localhost", () => {
+		setHostname("localhost");
+		expect(getCsrfCookieName()).toBe("spms_dev_csrf");
+	});
+
+	it("returns the development name on 127.0.0.1", () => {
+		setHostname("127.0.0.1");
+		expect(getCsrfCookieName()).toBe("spms_dev_csrf");
+	});
+});

--- a/frontend/src/shared/constants/auth.ts
+++ b/frontend/src/shared/constants/auth.ts
@@ -1,0 +1,52 @@
+/**
+ * Authentication cookie helpers.
+ *
+ * Single source of truth for the cookie names the frontend reads or clears,
+ * kept in sync with the backend's Django settings.
+ *
+ * The session cookie is intentionally absent: it is HttpOnly (and, in staging
+ * and production, scoped to the shared .dbca.wa.gov.au domain), so JavaScript
+ * cannot read or remove it. The backend expires it on logout; the frontend
+ * never touches it.
+ */
+
+/**
+ * CSRF cookie name per environment. Must mirror CSRF_COOKIE_NAMES in the
+ * backend settings. Staging and production share the .dbca.wa.gov.au parent
+ * domain, so they use distinct names to stop one environment's cookie from
+ * clobbering the other's. Production keeps the historical "spmscsrf" name so
+ * existing sessions aren't disrupted.
+ */
+const CSRF_COOKIE_NAMES = {
+	development: "spms_dev_csrf",
+	staging: "spms_test_csrf",
+	production: "spmscsrf",
+} as const;
+
+/**
+ * Resolve the CSRF cookie name for the current environment.
+ *
+ * A single built bundle serves every environment, so the name is resolved at
+ * runtime from the browser host rather than at build time. The staging check
+ * must come first because staging hosts also end with ".dbca.wa.gov.au".
+ */
+export const getCsrfCookieName = (): string => {
+	if (typeof window !== "undefined") {
+		const host = window.location.hostname;
+		if (host.includes("-test.dbca.wa.gov.au")) {
+			return CSRF_COOKIE_NAMES.staging;
+		}
+		if (host.endsWith(".dbca.wa.gov.au")) {
+			return CSRF_COOKIE_NAMES.production;
+		}
+	}
+	return CSRF_COOKIE_NAMES.development;
+};
+
+export const AUTH_COOKIES = {
+	/**
+	 * Legacy CSRF cookie name from earlier versions. Cleared on logout so a
+	 * stale cookie doesn't linger in the browser.
+	 */
+	LEGACY_CSRF: "csrf",
+} as const;

--- a/frontend/src/shared/constants/index.ts
+++ b/frontend/src/shared/constants/index.ts
@@ -3,6 +3,7 @@
  * Barrel export for all application constants
  */
 
+export * from "./auth";
 export * from "./breakpoints";
 export * from "./colors";
 export * from "./query";

--- a/frontend/src/shared/services/api/client.service.test.ts
+++ b/frontend/src/shared/services/api/client.service.test.ts
@@ -1,93 +1,396 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import Cookie from "js-cookie";
+import { ApiClientService } from "./client.service";
+import { AUTH_COOKIES, getCsrfCookieName } from "@/shared/constants";
 
 /**
- * API Client Error Handling Tests
+ * API Client tests.
  *
- * Tests verify that the API client correctly distinguishes between:
- * - 401: Always triggers logout (genuine auth failure)
- * - 403 without CSRF cookie: Triggers logout (session expired)
- * - 403 with CSRF cookie: Does NOT trigger logout (permission denied)
- * - 5xx / network errors: Never trigger logout (server issues)
+ * These exercise the real ApiClientService by mocking axios so the actual
+ * request/response interceptors and error-mapping logic run. The axios
+ * instance is replaced with a stub whose interceptor registrations are
+ * captured, letting us invoke the interceptor handlers directly.
  */
 
-describe("API Client Error Handling", () => {
-	describe("401 Response Handling", () => {
-		it("should always trigger unauthorised on 401", () => {
-			// 401 means the server explicitly rejected the credentials.
-			// This always triggers handleUnauthorised which:
-			// 1. Clears cookies (spmscsrf, csrf, sessionid)
-			// 2. Dispatches auth:unauthorised event
-			// 3. Calls the onUnauthorised handler if set
-			expect(true).toBe(true);
-		});
-	});
+// Minimal shapes for the values the interceptors actually touch.
+type RequestConfigLike = { headers: Record<string, string> };
+type ResponseLike = { data: unknown; status?: number };
+type AxiosErrorLike = {
+	response?: { status: number; data?: unknown };
+	request?: unknown;
+	message?: string;
+};
 
-	describe("403 Response Handling", () => {
-		it("should trigger unauthorised on 403 when CSRF cookie is missing (session expired)", () => {
-			// When a 403 occurs and there's no CSRF cookie, the session has expired.
-			// The interceptor checks: if (!Cookie.get("spmscsrf")) → handleUnauthorised()
-			// This prevents the user from being stuck on a page with an expired session.
-			const csrfValue = Cookie.get("spmscsrf");
-			expect(csrfValue).toBeUndefined(); // No cookie in test env = would trigger logout
-		});
+const { mockInstance, captured } = vi.hoisted(() => {
+	const captured = {
+		request: {
+			fulfilled: undefined as unknown,
+			rejected: undefined as unknown,
+		},
+		response: {
+			fulfilled: undefined as unknown,
+			rejected: undefined as unknown,
+		},
+	};
 
-		it("should NOT trigger unauthorised on 403 when CSRF cookie exists (permission denied)", () => {
-			// When a 403 occurs but the CSRF cookie exists, the user IS authenticated
-			// but simply doesn't have permission for this resource.
-			// The interceptor should NOT call handleUnauthorised in this case.
-			Cookie.set("spmscsrf", "test-token");
-			const csrfValue = Cookie.get("spmscsrf");
-			expect(csrfValue).toBe("test-token"); // Cookie exists = would NOT trigger logout
-			Cookie.remove("spmscsrf");
-		});
-	});
+	const mockInstance = {
+		interceptors: {
+			request: {
+				use: (fulfilled: unknown, rejected: unknown) => {
+					captured.request.fulfilled = fulfilled;
+					captured.request.rejected = rejected;
+				},
+			},
+			response: {
+				use: (fulfilled: unknown, rejected: unknown) => {
+					captured.response.fulfilled = fulfilled;
+					captured.response.rejected = rejected;
+				},
+			},
+		},
+		get: vi.fn(),
+		post: vi.fn(),
+		put: vi.fn(),
+		patch: vi.fn(),
+		delete: vi.fn(),
+	};
 
-	describe("5xx and Network Error Handling", () => {
-		it("should NOT trigger unauthorised on 500 errors", () => {
-			// Server errors (500, 502, 503) indicate the backend is having issues.
-			// The user's session may still be valid — clearing auth state would be wrong.
-			// The interceptor only logs the error and throws an ApiError.
-			expect(true).toBe(true);
-		});
-
-		it("should NOT trigger unauthorised on network errors (no response)", () => {
-			// Network errors (server unreachable, timeout) should never clear auth.
-			// The ServerDownFallback component handles recovery via polling.
-			expect(true).toBe(true);
-		});
-	});
-
-	describe("Request Interceptor", () => {
-		it("should add CSRF token to requests when cookie exists", () => {
-			// The request interceptor reads Cookie.get("spmscsrf") and sets
-			// config.headers["X-CSRFToken"] = csrfToken
-			expect(true).toBe(true);
-		});
-
-		it("should clean up old cookies when CSRF token is missing", () => {
-			// When no CSRF token exists, removes stale cookies:
-			// Cookie.remove("csrf"); Cookie.remove("sessionid");
-			expect(true).toBe(true);
-		});
-	});
+	return { mockInstance, captured };
 });
 
-describe("API Client Error Message Formatting", () => {
-	it("should return generic message for 5xx errors", () => {
-		// For status >= 500, createApiError always returns:
-		// "A server error occurred. Please try again later."
-		// This prevents HTML error pages from leaking into toast messages.
-		expect(true).toBe(true);
+vi.mock("axios", () => ({
+	default: {
+		create: () => mockInstance,
+	},
+}));
+
+vi.mock("js-cookie");
+vi.mock("@/shared/services/logger.service");
+
+// js-cookie is auto-mocked. Alias Cookie.get with a loose mock type so
+// mockReturnValue accepts our values (its real typing is overloaded).
+const mockCookieGet = Cookie.get as ReturnType<typeof vi.fn>;
+
+// Typed accessors for the captured interceptor handlers.
+const runRequest = (config: RequestConfigLike): RequestConfigLike =>
+	(captured.request.fulfilled as (c: RequestConfigLike) => RequestConfigLike)(
+		config
+	);
+
+const runRequestError = (error: unknown): Promise<unknown> =>
+	(captured.request.rejected as (e: unknown) => Promise<unknown>)(error);
+
+const runResponse = (response: ResponseLike): ResponseLike =>
+	(captured.response.fulfilled as (r: ResponseLike) => ResponseLike)(response);
+
+const runResponseError = (error: AxiosErrorLike): Promise<unknown> =>
+	(captured.response.rejected as (e: AxiosErrorLike) => Promise<unknown>)(
+		error
+	);
+
+describe("ApiClientService", () => {
+	let client: ApiClientService;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockCookieGet.mockReturnValue(undefined);
+		// Reconstructing re-registers the interceptors against this instance.
+		client = new ApiClientService();
 	});
 
-	it("should extract detail from Django error responses", () => {
-		// For 4xx errors with { detail: "..." }, uses the detail message
-		expect(true).toBe(true);
+	describe("request interceptor", () => {
+		it("adds the X-CSRFToken header when the CSRF cookie exists", () => {
+			mockCookieGet.mockReturnValue("csrf-token-123");
+
+			const config = runRequest({ headers: {} });
+
+			expect(config.headers["X-CSRFToken"]).toBe("csrf-token-123");
+			expect(Cookie.get).toHaveBeenCalledWith(getCsrfCookieName());
+		});
+
+		it("clears stale cookies and sets no header when CSRF is missing", () => {
+			mockCookieGet.mockReturnValue(undefined);
+
+			const config = runRequest({ headers: {} });
+
+			expect(config.headers["X-CSRFToken"]).toBeUndefined();
+			expect(Cookie.remove).toHaveBeenCalledWith(AUTH_COOKIES.LEGACY_CSRF);
+		});
+
+		it("rejects with the original error from the request error handler", async () => {
+			const error = new Error("request setup failed");
+			await expect(runRequestError(error)).rejects.toBe(error);
+		});
 	});
 
-	it("should extract field errors from Django validation responses", () => {
-		// For 4xx errors with { field: ["error"] }, formats as field errors
-		expect(true).toBe(true);
+	describe("response interceptor - success", () => {
+		it("passes successful responses through unchanged", () => {
+			const response = { data: { value: 1 }, status: 200 };
+			expect(runResponse(response)).toBe(response);
+		});
+	});
+
+	describe("response interceptor - authentication handling", () => {
+		it("logs out on 401 and clears the cookies it can reach", async () => {
+			const dispatchSpy = vi
+				.spyOn(window, "dispatchEvent")
+				.mockReturnValue(true);
+
+			await expect(
+				runResponseError({ response: { status: 401, data: {} } })
+			).rejects.toMatchObject({ status: 401 });
+
+			expect(Cookie.remove).toHaveBeenCalledWith(getCsrfCookieName());
+			expect(Cookie.remove).toHaveBeenCalledWith(AUTH_COOKIES.LEGACY_CSRF);
+
+			const event = dispatchSpy.mock.calls[0]?.[0] as CustomEvent;
+			expect(event.type).toBe("auth:unauthorised");
+
+			dispatchSpy.mockRestore();
+		});
+
+		it("calls a registered unauthorised handler on 401", async () => {
+			const onUnauthorised = vi.fn();
+			client.setUnauthorisedHandler(onUnauthorised);
+			const dispatchSpy = vi
+				.spyOn(window, "dispatchEvent")
+				.mockReturnValue(true);
+
+			await expect(
+				runResponseError({ response: { status: 401 } })
+			).rejects.toMatchObject({ status: 401 });
+
+			expect(onUnauthorised).toHaveBeenCalledTimes(1);
+			dispatchSpy.mockRestore();
+		});
+
+		it("logs out on 403 when the CSRF cookie is missing (session expired)", async () => {
+			mockCookieGet.mockReturnValue(undefined);
+			const dispatchSpy = vi
+				.spyOn(window, "dispatchEvent")
+				.mockReturnValue(true);
+
+			await expect(
+				runResponseError({
+					response: { status: 403, data: { detail: "Forbidden" } },
+				})
+			).rejects.toMatchObject({ status: 403 });
+
+			expect(Cookie.remove).toHaveBeenCalledWith(getCsrfCookieName());
+			expect(Cookie.remove).toHaveBeenCalledWith(AUTH_COOKIES.LEGACY_CSRF);
+			dispatchSpy.mockRestore();
+		});
+
+		it("does NOT log out on 403 when the CSRF cookie exists (permission denied)", async () => {
+			mockCookieGet.mockReturnValue("csrf-token-123");
+			const dispatchSpy = vi
+				.spyOn(window, "dispatchEvent")
+				.mockReturnValue(true);
+
+			await expect(
+				runResponseError({
+					response: {
+						status: 403,
+						data: { detail: "You do not have permission." },
+					},
+				})
+			).rejects.toMatchObject({
+				status: 403,
+				message: "You do not have permission.",
+			});
+
+			expect(Cookie.remove).not.toHaveBeenCalled();
+			expect(dispatchSpy).not.toHaveBeenCalled();
+			dispatchSpy.mockRestore();
+		});
+
+		it("does NOT log out on 500 server errors", async () => {
+			const dispatchSpy = vi
+				.spyOn(window, "dispatchEvent")
+				.mockReturnValue(true);
+
+			await expect(
+				runResponseError({
+					response: { status: 500, data: "<html>oops</html>" },
+				})
+			).rejects.toMatchObject({ status: 500 });
+
+			expect(Cookie.remove).not.toHaveBeenCalled();
+			expect(dispatchSpy).not.toHaveBeenCalled();
+			dispatchSpy.mockRestore();
+		});
+
+		it("does NOT log out on network errors (no response)", async () => {
+			const dispatchSpy = vi
+				.spyOn(window, "dispatchEvent")
+				.mockReturnValue(true);
+
+			await expect(
+				runResponseError({ request: {}, message: "Network Error" })
+			).rejects.toMatchObject({ status: 0 });
+
+			expect(Cookie.remove).not.toHaveBeenCalled();
+			expect(dispatchSpy).not.toHaveBeenCalled();
+			dispatchSpy.mockRestore();
+		});
+	});
+
+	describe("error message formatting", () => {
+		it("returns a generic message for 5xx errors", async () => {
+			await expect(
+				runResponseError({
+					response: { status: 503, data: "<html>err</html>" },
+				})
+			).rejects.toMatchObject({
+				status: 503,
+				message: "A server error occurred. Please try again later.",
+			});
+		});
+
+		it("uses the Django detail field", async () => {
+			await expect(
+				runResponseError({
+					response: { status: 400, data: { detail: "Invalid request" } },
+				})
+			).rejects.toMatchObject({ status: 400, message: "Invalid request" });
+		});
+
+		it("uses the first non_field_errors entry", async () => {
+			await expect(
+				runResponseError({
+					response: {
+						status: 400,
+						data: { non_field_errors: ["Bad combo", "Second"] },
+					},
+				})
+			).rejects.toMatchObject({ status: 400, message: "Bad combo" });
+		});
+
+		it("maps Django field errors and surfaces the first one", async () => {
+			await expect(
+				runResponseError({
+					response: {
+						status: 400,
+						data: { username: ["This field is required."] },
+					},
+				})
+			).rejects.toMatchObject({
+				status: 400,
+				message: "username: This field is required.",
+				fieldErrors: { username: ["This field is required."] },
+			});
+		});
+
+		it("prefers a single error string over field mapping", async () => {
+			await expect(
+				runResponseError({
+					response: { status: 400, data: { error: "Incorrect password" } },
+				})
+			).rejects.toMatchObject({ status: 400, message: "Incorrect password" });
+		});
+
+		it("uses short plain-string responses as the message", async () => {
+			await expect(
+				runResponseError({ response: { status: 400, data: "Something broke" } })
+			).rejects.toMatchObject({ status: 400, message: "Something broke" });
+		});
+
+		it("ignores HTML string bodies and keeps the default message", async () => {
+			await expect(
+				runResponseError({
+					response: { status: 400, data: "<!DOCTYPE html><html></html>" },
+				})
+			).rejects.toMatchObject({ status: 400, message: "An error occurred" });
+		});
+
+		it("falls back to a default message when there is no body", async () => {
+			await expect(
+				runResponseError({ response: { status: 400 } })
+			).rejects.toMatchObject({ status: 400, message: "An error occurred" });
+		});
+	});
+
+	describe("HTTP methods", () => {
+		it("get returns response.data and forwards the config", async () => {
+			const data = { id: 1 };
+			mockInstance.get.mockResolvedValue({ data });
+
+			const result = await client.get<typeof data>("users/1", {
+				params: { expand: true },
+			});
+
+			expect(result).toEqual(data);
+			expect(mockInstance.get).toHaveBeenCalledWith("users/1", {
+				params: { expand: true },
+			});
+		});
+
+		it("post returns response.data and forwards the body", async () => {
+			const data = { ok: true };
+			mockInstance.post.mockResolvedValue({ data });
+
+			const result = await client.post<typeof data>("users/log-in", {
+				username: "a",
+			});
+
+			expect(result).toEqual(data);
+			expect(mockInstance.post).toHaveBeenCalledWith(
+				"users/log-in",
+				{ username: "a" },
+				undefined
+			);
+		});
+
+		it("put returns response.data", async () => {
+			mockInstance.put.mockResolvedValue({ data: { updated: true } });
+			const result = await client.put<{ updated: boolean }>("users/1", {});
+			expect(result).toEqual({ updated: true });
+		});
+
+		it("patch returns response.data", async () => {
+			mockInstance.patch.mockResolvedValue({ data: { patched: true } });
+			const result = await client.patch<{ patched: boolean }>("users/1", {});
+			expect(result).toEqual({ patched: true });
+		});
+
+		it("delete returns response.data", async () => {
+			mockInstance.delete.mockResolvedValue({ data: { deleted: true } });
+			const result = await client.delete<{ deleted: boolean }>("users/1");
+			expect(result).toEqual({ deleted: true });
+		});
+	});
+
+	describe("blob methods", () => {
+		it("getBlob requests a blob response type", async () => {
+			const blob = new Blob(["file"]);
+			mockInstance.get.mockResolvedValue({ data: blob });
+
+			const result = await client.getBlob("documents/1");
+
+			expect(result).toBe(blob);
+			expect(mockInstance.get).toHaveBeenCalledWith("documents/1", {
+				responseType: "blob",
+			});
+		});
+
+		it("postBlob requests a blob response type and forwards the body", async () => {
+			const blob = new Blob(["pdf"]);
+			mockInstance.post.mockResolvedValue({ data: blob });
+
+			const result = await client.postBlob("documents/render", { id: 1 });
+
+			expect(result).toBe(blob);
+			expect(mockInstance.post).toHaveBeenCalledWith(
+				"documents/render",
+				{ id: 1 },
+				{ responseType: "blob" }
+			);
+		});
+	});
+
+	describe("configuration", () => {
+		it("exposes the raw axios instance", () => {
+			expect(client.getRawClient()).toBe(mockInstance);
+		});
 	});
 });

--- a/frontend/src/shared/services/api/client.service.ts
+++ b/frontend/src/shared/services/api/client.service.ts
@@ -6,6 +6,7 @@ import axios, {
 } from "axios";
 import Cookie from "js-cookie";
 import { logger } from "@/shared/services/logger.service";
+import { AUTH_COOKIES, getCsrfCookieName } from "@/shared/constants";
 import { API_CONFIG } from "./config";
 import type { DjangoErrorResponse } from "@/shared/types/api.types";
 import {
@@ -39,14 +40,13 @@ export class ApiClientService {
 		// Request interceptor to add CSRF token
 		this.client.interceptors.request.use(
 			(config) => {
-				const csrfToken = Cookie.get("spmscsrf");
+				const csrfToken = Cookie.get(getCsrfCookieName());
 
 				if (csrfToken) {
 					config.headers["X-CSRFToken"] = csrfToken;
 				} else {
-					// Clean up old cookies if CSRF token is missing
-					Cookie.remove("csrf");
-					Cookie.remove("sessionid");
+					// Clean up a stale legacy CSRF cookie if the token is missing
+					Cookie.remove(AUTH_COOKIES.LEGACY_CSRF);
 				}
 
 				return config;
@@ -74,7 +74,7 @@ export class ApiClientService {
 							});
 							// Only trigger unauthorised for session expiry (not permission denied)
 							// A 403 with no CSRF cookie means session expired
-							if (!Cookie.get("spmscsrf")) {
+							if (!Cookie.get(getCsrfCookieName())) {
 								logger.warn("No CSRF cookie with 403 - session expired");
 								await this.handleUnauthorised();
 							}
@@ -107,10 +107,10 @@ export class ApiClientService {
 	}
 
 	private async handleUnauthorised(): Promise<void> {
-		// Clear cookies
-		Cookie.remove("spmscsrf");
-		Cookie.remove("csrf");
-		Cookie.remove("sessionid");
+		// Only the readable CSRF cookies can be cleared here. The session
+		// cookie is HttpOnly and is expired by the backend on logout.
+		Cookie.remove(getCsrfCookieName());
+		Cookie.remove(AUTH_COOKIES.LEGACY_CSRF);
 
 		// Dispatch event that authStore listens to
 		window.dispatchEvent(new CustomEvent("auth:unauthorised"));


### PR DESCRIPTION
- Adds defence-in-depth to working HttpOnly cookie approach, separating envs where appropriate
- Added helper file for these settings
- Adjust code to conventional 400 from 200 on login fail (Login handled by SSO regardless)
- Removed some frontend deadcode & adjusted tests